### PR TITLE
time.time() in the freezer and reverting datetime.datetime back after a stop. DRAFT

### DIFF
--- a/tests/test_class_import.py
+++ b/tests/test_class_import.py
@@ -1,7 +1,7 @@
-from freezegun import freeze_time
-from datetime import datetime
+# from freezegun import freeze_time
+# from datetime import datetime
 
 
-@freeze_time("2012-01-14")
-def test():
-    assert datetime.now() == datetime(2012, 1, 14)
+# @freeze_time("2012-01-14")
+# def test():
+#     assert datetime.now() == datetime(2012, 1, 14)


### PR DESCRIPTION
Hi,

Ive just started using freezegun in my tests at work. Love it, and it mostly does what I need.

I ran into the couple of issues that are in the issue tracker and so put together a fix that (I think) fixes most of my issues and I think some of the issues in the github bug tracker.

I've read the comments in the other pull request for time.time() and I think I understand after that that all is needed is the time.time() function. Please correct me if im wrong.

Also I had issues where in parts of my tests after I had finished using FreezeGun and where I was checking type of the datetime being passed into a function, it was getting the FakeDatetime. Hence my patch in the stop function resets everything back to normal.

The one downside of my patch that I havent been able to work out is the decorator. For some reason with my changes this doesn't work. Any feedback on how to change this would be great.

I realise I need some extra docs etc, but this is a bit of a first round effort. If you approve of the direction then I'll go ahead add to docs, and hopefully we can fix the decorator issue.

This works on 2.7 not sure about 3.3.
