### PR TITLE
Ensure unittest.TestCase subclasses will be discovered.

### DIFF
--- a/tests/test_datetimes.py
+++ b/tests/test_datetimes.py
@@ -1,4 +1,6 @@
 import datetime
+import unittest
+
 from freezegun import freeze_time
 
 
@@ -84,3 +86,8 @@ def test_isinstance_without_active():
 
     today = datetime.date.today()
     assert isinstance(today, datetime.date)
+
+@freeze_time('2013-04-09')
+class TestUnitTestClassDecorator(unittest.TestCase):
+    def test_class_decorator_works_on_unittest(self):
+        self.assertEqual(datetime.date(2013,4,9), datetime.date.today())


### PR DESCRIPTION
`unittest` test discovery generally looks for classes that are a subclass of `unittest.TestCase`.

When a class is decorated, a function object is returned. This will not be discovered by the test discovery tools.

Instead, we can inject a Mixin, that calls `freezer.start()` before `.setUp()`, and `freezer.stop()` after `.tearDown()`.

Since django uses unittest.TestCase subclasses, this patch enables decorating django test case subclasses, too.

Tests are included.

Resolves #16.
