### PR TITLE
Fix for py.test

### DIFF
--- a/freezegun/api.py
+++ b/freezegun/api.py
@@ -117,7 +117,7 @@ class _freeze_time():
         for module in modules:
             if module is None:
                 continue
-            if module.__name__ != 'datetime':
+            if hasattr(module, "__name__") and module.__name__ != 'datetime':
                 if hasattr(module, 'datetime') and module.datetime == real_datetime:
                     module.datetime = FakeDatetime
                 if hasattr(module, 'date') and module.date == real_date:


### PR DESCRIPTION
In order for freeze gun to play well with py.test

The issue is that some modules apparently don't have a **name** (it appears to be lazy loaded) Just adding a check for the **name** attribute before trying to access it.

Test case showing that freezegun and py.test didn't work well together. https://gist.github.com/PuercoPop/5357159
