### PR TITLE
Use fake class for min and max in order for pickle to work

### DIFF
--- a/freezegun/api.py
+++ b/freezegun/api.py
@@ -34,6 +34,23 @@ class FakeDateMeta(type):
         return isinstance(obj, real_date)
 
 
+def datetime_to_fakedatetime(datetime):
+    return FakeDatetime(datetime.year,
+                        datetime.month,
+                        datetime.day,
+                        datetime.hour,
+                        datetime.minute,
+                        datetime.second,
+                        datetime.microsecond,
+                        datetime.tzinfo)
+
+
+def date_to_fakedate(date):
+    return FakeDate(date.year,
+                    date.month,
+                    date.day)
+
+
 class FakeDate(with_metaclass(FakeDateMeta, real_date)):
     date_to_freeze = None
 
@@ -59,6 +76,9 @@ class FakeDate(with_metaclass(FakeDateMeta, real_date)):
     def today(cls):
         result = cls.date_to_freeze
         return date_to_fakedate(result)
+
+FakeDate.min = date_to_fakedate(real_date.min)
+FakeDate.max = date_to_fakedate(real_date.max)
 
 
 class FakeDatetimeMeta(FakeDateMeta):
@@ -102,22 +122,8 @@ class FakeDatetime(with_metaclass(FakeDatetimeMeta, real_datetime, FakeDate)):
         result = cls.time_to_freeze
         return result
 
-
-def datetime_to_fakedatetime(datetime):
-    return FakeDatetime(datetime.year,
-                        datetime.month,
-                        datetime.day,
-                        datetime.hour,
-                        datetime.minute,
-                        datetime.second,
-                        datetime.microsecond,
-                        datetime.tzinfo)
-
-
-def date_to_fakedate(date):
-    return FakeDate(date.year,
-                    date.month,
-                    date.day)
+FakeDatetime.min = datetime_to_fakedatetime(real_datetime.min)
+FakeDatetime.max = datetime_to_fakedatetime(real_datetime.max)
 
 
 class FreezeMixin(object):

--- a/tests/test_datetimes.py
+++ b/tests/test_datetimes.py
@@ -1,3 +1,4 @@
+import pickle
 import time
 import datetime
 import unittest
@@ -6,6 +7,7 @@ import locale
 from nose.plugins import skip
 
 from freezegun import freeze_time
+from freezegun.api import FakeDatetime, FakeDate, real_datetime, real_date
 
 
 class temp_locale(object):
@@ -194,3 +196,64 @@ def test_isinstance_without_active():
 class TestUnitTestClassDecorator(unittest.TestCase):
     def test_class_decorator_works_on_unittest(self):
         self.assertEqual(datetime.date(2013,4,9), datetime.date.today())
+
+
+def assert_class_of_datetimes(right_class, wrong_class):
+    datetime.datetime.min.__class__.should.equal(right_class)
+    datetime.datetime.max.__class__.should.equal(right_class)
+    datetime.date.min.__class__.should.equal(right_class)
+    datetime.date.max.__class__.should.equal(right_class)
+    datetime.datetime.min.__class__.shouldnt.equal(wrong_class)
+    datetime.datetime.max.__class__.shouldnt.equal(wrong_class)
+    datetime.date.min.__class__.shouldnt.equal(wrong_class)
+    datetime.date.max.__class__.shouldnt.equal(wrong_class)
+
+
+def test_min_and_max():
+    freezer = freeze_time("2012-01-14")
+    real_datetime = datetime
+
+    freezer.start()
+    datetime.datetime.min.__class__.should.equal(FakeDatetime)
+    datetime.datetime.max.__class__.should.equal(FakeDatetime)
+    datetime.date.min.__class__.should.equal(FakeDate)
+    datetime.date.max.__class__.should.equal(FakeDate)
+    datetime.datetime.min.__class__.shouldnt.equal(real_datetime)
+    datetime.datetime.max.__class__.shouldnt.equal(real_datetime)
+    datetime.date.min.__class__.shouldnt.equal(real_date)
+    datetime.date.max.__class__.shouldnt.equal(real_date)
+
+    freezer.stop()
+    datetime.datetime.min.__class__.should.equal(datetime.datetime)
+    datetime.datetime.max.__class__.should.equal(datetime.datetime)
+    datetime.date.min.__class__.should.equal(datetime.date)
+    datetime.date.max.__class__.should.equal(datetime.date)
+    datetime.datetime.min.__class__.shouldnt.equal(FakeDatetime)
+    datetime.datetime.max.__class__.shouldnt.equal(FakeDatetime)
+    datetime.date.min.__class__.shouldnt.equal(FakeDate)
+    datetime.date.max.__class__.shouldnt.equal(FakeDate)
+
+
+def assert_pickled_datetimes_equal_original():
+    min_datetime = datetime.datetime.min
+    max_datetime = datetime.datetime.max
+    min_date = datetime.date.min
+    max_date = datetime.date.max
+    now = datetime.datetime.now()
+    today = datetime.date.today()
+    assert pickle.loads(pickle.dumps(min_datetime)) == min_datetime
+    assert pickle.loads(pickle.dumps(max_datetime)) == max_datetime
+    assert pickle.loads(pickle.dumps(min_date)) == min_date
+    assert pickle.loads(pickle.dumps(max_date)) == max_date
+    assert pickle.loads(pickle.dumps(now)) == now
+    assert pickle.loads(pickle.dumps(today)) == today
+
+
+def test_pickle():
+    freezer = freeze_time("2012-01-14")
+
+    freezer.start()
+    assert_pickled_datetimes_equal_original()
+
+    freezer.stop()
+    assert_pickled_datetimes_equal_original()


### PR DESCRIPTION
When freeze_time is used, min and max return real datetime objects. These objects cannot be pickled. datetime.min returns datetime(1, 1, 1, 0, 0). Pickle checks the class of datetime(1, 1, 1, 0, 0) which is then converted to a FakeDatetime. The classes do not match and the object is not pickled.

I have added min and max as fake objects to the classes.
