### PR TITLE
Add workaround for clash with "six" on Python 3

### DIFF
--- a/freezegun/api.py
+++ b/freezegun/api.py
@@ -197,6 +197,8 @@ class _freeze_time(object):
         time.time = real_time
 
         for mod_name, module in sys.modules.items():
+            if mod_name.startswith('six.moves.'):
+                continue
             if mod_name != 'datetime':
                 if hasattr(module, 'datetime') and module.datetime == FakeDatetime:
                     module.datetime = real_datetime


### PR DESCRIPTION
fixes #31

The "six" library changes the list of modules on the fly when we access a module attribute; this causes a "RuntimeError: dictionary changed size during iteration" under Python 3. This workaround excludes modules matching `six.moves.*` from attribute checking on "unpatching" phase.
