### PR TITLE
Unconstrain six.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 import sys
 from setuptools import setup, find_packages
 
-requires = ['six<=1.4']
+requires = ['six']
 
 if sys.version_info[0] == 2:
     requires += ['python-dateutil>=1.0, <2.0, >=2.1']


### PR DESCRIPTION
I checked, and `make test` still ran with a more modern six.  Is there a reason why six is constrained to less than version 1.4?
