### PR TITLE
Second part of fix for #35

### DIFF
--- a/freezegun/api.py
+++ b/freezegun/api.py
@@ -197,7 +197,7 @@ class _freeze_time(object):
         datetime.date = real_date
         time.time = real_time
 
-        for mod_name, module in sys.modules.items():
+        for mod_name, module in list(sys.modules.items()):
             if mod_name.startswith('six.moves.'):
                 continue
             if mod_name != 'datetime':


### PR DESCRIPTION
I got the same error as in #35, but in the stop method instead of the start method. #36 only converted sys.modules.items() to a list in start, but that also needs to be done in stop.
