### PR TITLE
datetime.datetime.today() should return a FakeDateTime

### DIFF
--- a/freezegun/api.py
+++ b/freezegun/api.py
@@ -118,6 +118,10 @@ class FakeDatetime(with_metaclass(FakeDatetimeMeta, real_datetime, FakeDate)):
         return datetime_to_fakedatetime(result)
 
     @classmethod
+    def today(cls):
+        return cls.now(tz=None)
+
+    @classmethod
     def utcnow(cls):
         result = cls.time_to_freeze
         return datetime_to_fakedatetime(result)

--- a/tests/test_datetimes.py
+++ b/tests/test_datetimes.py
@@ -48,7 +48,7 @@ def test_simple_api():
     assert datetime.datetime.now() == datetime.datetime(2012, 1, 14)
     assert datetime.datetime.utcnow() == datetime.datetime(2012, 1, 14)
     assert datetime.date.today() == datetime.date(2012, 1, 14)
-    assert datetime.datetime.now().today() == datetime.date(2012, 1, 14)
+    assert datetime.datetime.now().today() == datetime.datetime(2012, 1, 14)
     freezer.stop()
     assert time.time() != expected_timestamp
     assert datetime.datetime.now() != datetime.datetime(2012, 1, 14)


### PR DESCRIPTION
At present, `datetime.datetime.today()` returns a `FakeDate` object when time has been frozen. According to the documentation, it should return "...the current local datetime, with `tzinfo` `None`.".
