### PR TITLE
Time not frozen if TestCase has a setUp method that does not call super()

### DIFF
--- a/freezegun/api.py
+++ b/freezegun/api.py
@@ -130,21 +130,6 @@ FakeDatetime.min = datetime_to_fakedatetime(real_datetime.min)
 FakeDatetime.max = datetime_to_fakedatetime(real_datetime.max)
 
 
-class FreezeMixin(object):
-    """
-    With unittest.TestCase subclasses, we must return the class from our
-    freeze_time decorator, else test discovery tools may not discover the
-    test. Instead, we inject this mixin, which starts and stops the freezer
-    before and after each test.
-    """
-    def setUp(self):
-        self._freezer.start()
-        super(FreezeMixin, self).setUp()
-
-    def tearDown(self):
-        super(FreezeMixin, self).tearDown()
-        self._freezer.stop()
-
 class _freeze_time(object):
 
     def __init__(self, time_to_freeze_str, tz_offset):
@@ -155,9 +140,9 @@ class _freeze_time(object):
 
     def __call__(self, func):
         if inspect.isclass(func) and issubclass(func, unittest.TestCase):
-            # Inject a mixin that does what we want, as otherwise we
-            # would not be found by the test discovery tool.
-            func.__bases__ = (FreezeMixin,) + func.__bases__
+            # Decorate the TestCase's run method, which is invoked for each test
+            # method.
+            func.run = self(func.run)
             # And, we need a reference to this object...
             func._freezer = self
             return func

--- a/tests/test_datetimes.py
+++ b/tests/test_datetimes.py
@@ -203,6 +203,14 @@ class TestUnitTestClassDecorator(unittest.TestCase):
     def test_class_decorator_works_on_unittest(self):
         self.assertEqual(datetime.date(2013,4,9), datetime.date.today())
 
+@freeze_time('2013-04-09')
+class TestUnitTestClassDecoratorWithSetup(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    def test_class_decorator_works_on_unittest(self):
+        self.assertEqual(datetime.date(2013,4,9), datetime.date.today())
+
 
 def assert_class_of_datetimes(right_class, wrong_class):
     datetime.datetime.min.__class__.should.equal(right_class)


### PR DESCRIPTION
Since `unittest.TestCase.setUp` is a stub function, it's extremely common for subclasses' `setUp` methods to not call `super()`.  This translates to time not being frozen for these subclasses when decorated.  Also, worryingly, if a custom `setUp` called `super()`, but a custom `tearDown` didn't... time would probably be frozen for the remainder of the test run!

A more reliable method, in my experience, is passing the decoration on to the TestCase subclass's `run` method.  This works because unittest tests are run by instantiating the TestCase subclass with the name of the test method to run, and then calling its `run` method.
