### PR TITLE
Allow specification of which modules to ignore

### DIFF
--- a/freezegun/api.py
+++ b/freezegun/api.py
@@ -174,7 +174,7 @@ class _freeze_time(object):
         for mod_name, module in list(sys.modules.items()):
             if module is None:
                 continue
-            if mod_name.startswith(self.ignore):
+            if mod_name.startswith(tuple(self.ignore)):
                 continue
             if hasattr(module, "__name__") and module.__name__ != 'datetime':
                 if hasattr(module, 'datetime') and module.datetime == real_datetime:
@@ -198,7 +198,7 @@ class _freeze_time(object):
         time.time = real_time
 
         for mod_name, module in list(sys.modules.items()):
-            if mod_name.startswith(self.ignore):
+            if mod_name.startswith(tuple(self.ignore)):
                 continue
             if mod_name != 'datetime':
                 if hasattr(module, 'datetime') and module.datetime == FakeDatetime:


### PR DESCRIPTION
This patch adds support for a third parameter, `ignore`, to `freeze_time` which allows the user to specify what additional imported modules they want exempt from freezegun's patching process. By default it'll add the `'six.moves.'` and `'django.utils.six.moves.'` items.

I propose this because I've run into an issue specifically with selenium's [wait.until](https://code.google.com/p/selenium/source/browse/py/selenium/webdriver/support/wait.py#60) function which relies on `time.time` and `time.sleep` in order to wait for the webdriver to finish its processing. I didn't want to suggest adding yet another case to the exemption list, and instead thought it would be more extensible to allow the user to specify more modules.
