### PR TITLE
Use a saner requirements for python-dateutil

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup, find_packages
 requires = ['six']
 
 if sys.version_info[0] == 2:
-    requires += ['python-dateutil>=1.0, <2.0, >=2.1']
+    requires += ['python-dateutil>=1.0, != 2.0']
 else:
     # Py3k
     requires += ['python-dateutil>=2.0']


### PR DESCRIPTION
The requirement `>=1.0, <2.0, >=2.1` doesn't make a lot of logical sense and it
will break in the future. There is no version that is `>= 1.0`, and `< 2.0`, and
`>= 2.1` because these versions are mutually exclusive. Even if you interpret
the `,` as OR it still doesn't make sense because this includes every version.

What this spec is actually trying to represent is any version `>= 1.0` but not
`2.0`, so instead we'll just say that.
