### PR TITLE
Fixed #51 - Set __wrapped__ on the decorated function

### DIFF
--- a/freezegun/api.py
+++ b/freezegun/api.py
@@ -292,6 +292,11 @@ class _freeze_time(object):
                 result = func(*args, **kwargs)
             return result
         functools.update_wrapper(wrapper, func)
+
+        # update_wrapper already sets __wrapped__ in Python 3.2+, this is only
+        # needed for Python 2.x support
+        wrapper.__wrapped__ = func
+
         return wrapper
 
 

--- a/tests/test_datetimes.py
+++ b/tests/test_datetimes.py
@@ -161,6 +161,14 @@ def test_decorator():
     assert datetime.datetime.now() == datetime.datetime(2012, 1, 14)
 
 
+def test_decorator_wrapped_attribute():
+    def to_decorate():
+        pass
+
+    wrapped = freeze_time("2014-01-14")(to_decorate)
+
+    assert wrapped.__wrapped__ is to_decorate
+
 @freeze_time("2012-01-14")
 class Tester(object):
     def test_the_class(self):


### PR DESCRIPTION
`functools.update_wrapper` and `functools.wraps` sets `__wrapped__` in Python >= 3.2, so this fix only affects Python 2.X in freezegun.

The mock library uses a similar fix:
https://code.google.com/p/mock/source/browse/mock.py?spec=svnd356250e275daa62b2972521885f42fa639341e6&r=e7c5f97dc1b486fbf2e7fb111ec3e6675f9d3418#65

This change allows pytest to correctly figure out the real argument names and then inject fixtures properly:
https://bitbucket.org/hpk42/pytest/src/d91265465608bd3777ab0c882e5d68335d7472dd/_pytest/python.py?at=default#cl-1916
