### PR TITLE
Replace based on identity (is) comparision.

### DIFF
--- a/freezegun/api.py
+++ b/freezegun/api.py
@@ -249,13 +249,13 @@ class _freeze_time(object):
                     # For certain libraries, this can result in ImportError(_winreg) or AttributeError (celery)
                     continue
                 try:
-                    if attribute_value == real_datetime:
+                    if attribute_value is real_datetime:
                         setattr(module, module_attribute, FakeDatetime)
                         self.undo_changes.append((module, module_attribute, real_datetime))
-                    elif attribute_value == real_date:
+                    elif attribute_value is real_date:
                         setattr(module, module_attribute, FakeDate)
                         self.undo_changes.append((module, module_attribute, real_date))
-                    elif attribute_value == real_time:
+                    elif attribute_value is real_time:
                         setattr(module, module_attribute, fake_time)
                         self.undo_changes.append((module, module_attribute, real_time))
                 except:

--- a/tests/fake_module.py
+++ b/tests/fake_module.py
@@ -13,3 +13,16 @@ def fake_date_function():
 
 def fake_time_function():
     return time()
+
+
+class EqualToAnything(object):
+    description = 'This is the equal_to_anything object'
+
+    def __eq__(self, other):
+        return True
+
+    def __neq__(self, other):
+        return False
+
+
+equal_to_anything = EqualToAnything()

--- a/tests/test_class_import.py
+++ b/tests/test_class_import.py
@@ -1,6 +1,8 @@
 import sure
 import time
-from .fake_module import fake_datetime_function, fake_date_function, fake_time_function
+from .fake_module import (fake_datetime_function, fake_date_function, fake_time_function,
+                          equal_to_anything)
+from . import fake_module
 from freezegun import freeze_time
 from freezegun.api import FakeDatetime
 import datetime
@@ -54,3 +56,8 @@ def test_isinstance_works():
     isinstance(now, datetime.datetime).should.equal(True)
     isinstance(now, datetime.date).should.equal(True)
     freezer.stop()
+
+
+@freeze_time('2011-01-01')
+def test_avoid_replacing_equal_to_anything():
+    assert fake_module.equal_to_anything.description == 'This is the equal_to_anything object'


### PR DESCRIPTION
Special objects that overrides **eq** which always returns True confuses the replacement.

Checking for the replacement functions by identity solves this problem. Equal (==) does identity comparisions anyways unless **eq** is overriden.
