### PR TITLE
Include the tests in the releases but do not install them

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
 include README.rst LICENSE AUTHORS.rst
-recursive-exclude tests *
+recursive-include tests *

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     author='Steve Pulec',
     author_email='spulec@gmail',
     url='https://github.com/spulec/freezegun',
-    packages=find_packages(exclude=("tests", "tests.*",)),
+    packages=['freezegun'],
     install_requires=requires,
     include_package_data=True,
     classifiers=[


### PR DESCRIPTION
Updating the MANIFEST.in file allows making sure the tests are included in the release tarball generated via ``python setup.py sdist`` but the ``setup.py`` needed a small adjustment to prevent it from installing them.

Fixes https://github.com/spulec/freezegun/issues/75
Fixes https://github.com/spulec/freezegun/issues/27