### PR TITLE
tox.ini: Add pypy and pypy3 envs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,9 @@ language: python
 python:
   - 2.6
   - 2.7
+  - pypy
   - 3.3
+  - 3.4
 script: make travis
 install:
   - pip install .

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py26, py27, py33, py34
+envlist = py26, py27, pypy, py33, py34, pypy3
 
 [testenv]
 commands = make test


### PR DESCRIPTION
It looks like the tests fail on PyPy.

See:

- https://gist.github.com/msabramo/d983f597ea20d261ff2f
- https://travis-ci.org/spulec/freezegun/jobs/50094774