### PR TITLE
Fix PyPy problems

### DIFF
--- a/freezegun/api.py
+++ b/freezegun/api.py
@@ -39,7 +39,9 @@ class FakeLocalTime(object):
     def __init__(self, time_to_freeze):
         self.time_to_freeze = time_to_freeze
 
-    def __call__(self):
+    def __call__(self, t=None):
+        if t is not None:
+            return real_localtime(t)
         shifted_time = self.time_to_freeze - datetime.timedelta(seconds=time.timezone)
         return shifted_time.timetuple()
 
@@ -48,7 +50,9 @@ class FakeGMTTime(object):
     def __init__(self, time_to_freeze):
         self.time_to_freeze = time_to_freeze
 
-    def __call__(self):
+    def __call__(self, t=None):
+        if t is not None:
+            return real_gmtime(t)
         return self.time_to_freeze.timetuple()
 
 


### PR DESCRIPTION
PyPy appears to rely on the ability to call localtime and gmtime with an
argument, which I guess CPython doesn't.

This fixes errors like these:

```pytb
tests/unit/test_unit_outdated.py:143: in test_global_state
    state.save('2.0', datetime.datetime.utcnow())
/usr/local/Cellar/pypy/2.4.0_2/libexec/lib_pypy/datetime.py:1554: in utcnow
    return cls.utcfromtimestamp(t)
/usr/local/Cellar/pypy/2.4.0_2/libexec/lib_pypy/datetime.py:1540: in utcfromtimestamp
    y, m, d, hh, mm, ss, weekday, jday, dst = _time.gmtime(t)
E   TypeError: __call__() takes exactly 1 argument (2 given)
```