### PR TITLE
class decoration must respect staticmethods and other non-test callables

### DIFF
--- a/freezegun/api.py
+++ b/freezegun/api.py
@@ -235,11 +235,11 @@ class _freeze_time(object):
                 continue
 
             attr_value = getattr(klass, attr)
-            if not hasattr(attr_value, "__call__"):
-                continue
 
-            # Check if this is a classmethod. If so, skip patching
-            if inspect.ismethod(attr_value) and attr_value.__self__ is klass:
+            # Skip patching classmethods, staticmethods and non-method callables
+            # (but do recurse into nested classes)
+            if not inspect.isclass(attr_value) and (not inspect.ismethod(attr_value) or
+                                                    attr_value.__self__ is klass):
                 continue
 
             try:

--- a/tests/test_datetimes.py
+++ b/tests/test_datetimes.py
@@ -282,10 +282,24 @@ def test_isinstance_without_active():
     today = datetime.date.today()
     assert isinstance(today, datetime.date)
 
+
+class Callable(object):
+
+    def __call__(self, *args, **kws):
+        return (args, kws)
+
+
 @freeze_time('2013-04-09')
 class TestUnitTestClassDecorator(unittest.TestCase):
+
     def setUp(self):
         self.assertEqual(datetime.date(2013,4,9), datetime.date.today())
+
+    a_mock = Callable()
+
+    @staticmethod
+    def helper():
+        return datetime.date.today()
 
     @classmethod
     def setUpClass(cls):
@@ -293,6 +307,13 @@ class TestUnitTestClassDecorator(unittest.TestCase):
 
     def test_class_decorator_works_on_unittest(self):
         self.assertEqual(datetime.date(2013,4,9), datetime.date.today())
+
+    def test_class_decorator_respects_staticmethod(self):
+        self.assertEqual(self.helper(), datetime.date(2013, 4, 9))
+
+    def test_class_decorator_respects_callable_object(self):
+        self.assertIsInstance(self.a_mock, Callable)
+
 
 @freeze_time('2013-04-09')
 class TestUnitTestClassDecoratorWithSetup(unittest.TestCase):

--- a/tests/test_datetimes.py
+++ b/tests/test_datetimes.py
@@ -2,6 +2,7 @@ import time
 import datetime
 import unittest
 import locale
+import sys
 
 from nose.plugins import skip
 from tests import utils
@@ -311,8 +312,15 @@ class TestUnitTestClassDecorator(unittest.TestCase):
     def test_class_decorator_respects_staticmethod(self):
         self.assertEqual(self.helper(), datetime.date(2013, 4, 9))
 
-    def test_class_decorator_respects_callable_object(self):
-        self.assertIsInstance(self.a_mock, Callable)
+    def test_class_decorator_skips_callable_object_py2(self):
+        if sys.version_info[0] != 2:
+            raise skip.SkipTest("test target is Python2")
+        self.assertEqual(self.a_mock.__class__, Callable)
+
+    def test_class_decorator_wraps_callable_object_py3(self):
+        if sys.version_info[0] != 3:
+            raise skip.SkipTest("test target is Python3")
+        self.assertEqual(self.a_mock.__wrapped__.__class__, Callable)
 
 
 @freeze_time('2013-04-09')


### PR DESCRIPTION
In upgrading from 0.1.18, my app's test suite ran into a heap of trouble with freezegun's class decorator interface. I still don't think I've tracked down all of it &ndash; and I've had to undo the app's use of the class decorator for now &ndash; but the most visible issue stemmed from the changes to `_freeze_time.__call__` and `decorate_class`, which were previously much more strict about which entities to patch.

I don't propose to return to a `unittest`-centric decorator, but I think these changes are reasonable; so long as we're skipping `classmethod`, we really don't want to patch `staticmethod` and non-method callables. As a concrete example, we have tests like the following:

    import mock
    from unittest import TestCase

    class TestThings(TestCase):

        urllib2_patch = mock.patch('urllib2.urlopen', …)

        @staticmethod
        def do_some_help(some_input):
            …

        @urllib2_patch
        def test_1(self, _urllib2_mock):
            helpful_output = self.do_some_help(some_input)
            …

Without these changes, the module fails on import, as freezegun attempts to wrap the `mock` library's patch object &ndash; but raises `AttributeError` on `__name__`. Or, `test_1` fails, because freezegun has wrapped `do_some_help`, such that it's no longer a `staticmethod` and takes additional arguments ("self").

Anyway, thanks for the useful library!