### PR TITLE
class decoration must ignore nested classes

### DIFF
--- a/tests/test_datetimes.py
+++ b/tests/test_datetimes.py
@@ -293,10 +293,12 @@ class Callable(object):
 @freeze_time('2013-04-09')
 class TestUnitTestClassDecorator(unittest.TestCase):
 
-    def setUp(self):
-        self.assertEqual(datetime.date(2013,4,9), datetime.date.today())
-
     a_mock = Callable()
+
+    class NotATestClass(object):
+
+        def perform_operation(self):
+            return datetime.date.today()
 
     @staticmethod
     def helper():
@@ -304,7 +306,10 @@ class TestUnitTestClassDecorator(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        assert datetime.date(2013,4,9) != datetime.date.today()
+        assert datetime.date(2013, 4, 9) != datetime.date.today()
+
+    def setUp(self):
+        self.assertEqual(datetime.date(2013, 4, 9), datetime.date.today())
 
     def test_class_decorator_works_on_unittest(self):
         self.assertEqual(datetime.date(2013,4,9), datetime.date.today())
@@ -321,6 +326,11 @@ class TestUnitTestClassDecorator(unittest.TestCase):
         if sys.version_info[0] != 3:
             raise skip.SkipTest("test target is Python3")
         self.assertEqual(self.a_mock.__wrapped__.__class__, Callable)
+
+    @freeze_time('2001-01-01')
+    def test_class_decorator_ignores_nested_class(self):
+        not_a_test = self.NotATestClass()
+        self.assertEqual(not_a_test.perform_operation(), datetime.date(2001, 1, 1))
 
 
 @freeze_time('2013-04-09')


### PR DESCRIPTION
I figured out what else was causing tests to fail &ndash; the class decorator's wrapping arbitrary methods on classes nested under the test class.

The Django `TestCase` has a reference to the HTTP request `Client` class &ndash; defined on `SimpleTestCase.client_class`. (This allows you to override the class that's initialized and set on the test case instance at `self.client`.) Because `_freeze_time.decorate_class` wasn't excluding nested classes, it would recurse into such classes and patch their methods, including `Client.get`, `.post`, *etc.*.

This might not be an issue for the tests in the decorated test class, but any subsequent tests that didn't *re-patch* this nested class's methods (by decorating themselves with `freeze_time`) would see crazy side-effects &ndash; for example, their sessions would be created far in the past, such that they were immediately expired, and so session data would never set. Tests which didn't even import freezegun would pass when run alone but fail when run as part of the full suite.

I agree that freezegun shouldn't assume a `unittest.TestCase` class interface, but I'm not sure why it *should* assume that the methods of nested classes are valid targets; and, as in the example above, to do so has pernicious side-effects.

For that matter, I think it would be nice to further restrict the decorator from touching non-function callables (such as the "mock" object). And, there's really no need for it to touch any methods but those which are actually tests; but, we don't know what the test framework / test run will consider a test, and I don't see a lot of harm in continuing to patch every function.

This change slightly refactors the work of the last pull and makes decoration exclude nested classes. (To see the full change relative to when I started, see [here](https://github.com/spulec/freezegun/compare/0.3.1...jesteria:even-stricter-class-decoration?expand=1#diff-80ef255f3bb85cfd652668d719317c10R232).)

I think it still might be a good idea to further exclude callables which don't satisfy `inspect.isfunction()` &ndash; a test collection defined by placing non-function callable objects under a class definition is a pretty weird one; and, `isfunction()` would exclude "mock" and "patch" objects. But, with the last pull, it isn't a problem for me to continue to patch these.