### PR TITLE
Fix FakeTime.__call__() to return the correct value when daylight savings is in effect.

### DIFF
--- a/freezegun/api.py
+++ b/freezegun/api.py
@@ -3,6 +3,7 @@ import functools
 import inspect
 import sys
 import time
+import calendar
 
 from dateutil import parser
 
@@ -31,8 +32,7 @@ class FakeTime(object):
         self.previous_time_function = previous_time_function
 
     def __call__(self):
-        shifted_time = self.time_to_freeze - datetime.timedelta(seconds=time.timezone)
-        return time.mktime(shifted_time.timetuple()) + shifted_time.microsecond / 1000000.0
+        return calendar.timegm(self.time_to_freeze.timetuple()) + self.time_to_freeze.microsecond / 1000000.0
 
 
 class FakeLocalTime(object):

--- a/tests/test_datetimes.py
+++ b/tests/test_datetimes.py
@@ -114,6 +114,11 @@ def test_time_with_microseconds():
     assert time.time() == 1.123456
     freezer.stop()
 
+def test_time_with_dst():
+    freezer = freeze_time(datetime.datetime(1970, 6, 1, 0, 0, 1, 123456))
+    freezer.start()
+    assert time.time() == 13046401.123456
+    freezer.stop()
 
 def test_bad_time_argument():
     try:


### PR DESCRIPTION
The previous implementation was dependent on `mktime` which assumes the provided timetuple is in _local_ time.
The `time_to_freeze` is UTC, so `__call__` was attempting to compensate for this by using `time.timezone` to offset `time_to_freeze` first.
The problem is that `time.timezone` ignores daylight savings. When daylight savings is in effect, `time.timezone` is wrong by an hour and consequently `__call__` returns a timestamp which is an hour earlier than it should be.

This issue can be addressed, and the code made much cleaner, by using simply `calendar.timegm` instead of `mktime`. `calendar.timegm` assumes the given time is in UTC so no timezone adjustment is needed and timestamp will always be correct, daylight savings or otherwise.