### PR TITLE
Improves handling of date and datetime objects in freeze_time

### DIFF
--- a/freezegun/api.py
+++ b/freezegun/api.py
@@ -217,7 +217,12 @@ def pickle_fake_datetime(datetime_):
 class _freeze_time(object):
 
     def __init__(self, time_to_freeze_str, tz_offset, ignore):
-        time_to_freeze = parser.parse(time_to_freeze_str)
+        if isinstance(time_to_freeze_str, datetime.datetime):
+            time_to_freeze = time_to_freeze_str
+        elif isinstance(time_to_freeze_str, datetime.date):
+            time_to_freeze = datetime.datetime.combine(time_to_freeze_str, datetime.time())
+        else:
+            time_to_freeze = parser.parse(time_to_freeze_str)
         time_to_freeze = convert_to_timezone_naive(time_to_freeze)
 
         self.time_to_freeze = time_to_freeze
@@ -351,16 +356,13 @@ class _freeze_time(object):
 
 
 def freeze_time(time_to_freeze, tz_offset=0, ignore=None):
-    if isinstance(time_to_freeze, datetime.date):
-        time_to_freeze = time_to_freeze.isoformat()
-
     # Python3 doesn't have basestring, but it does have str.
     try:
         string_type = basestring
     except NameError:
         string_type = str
 
-    if not isinstance(time_to_freeze, string_type):
+    if not isinstance(time_to_freeze, (string_type, datetime.date)):
         raise TypeError(('freeze_time() expected a string, date instance, or '
                          'datetime instance, but got type {0}.').format(type(time_to_freeze)))
     if ignore is None:

--- a/tests/test_datetimes.py
+++ b/tests/test_datetimes.py
@@ -183,6 +183,11 @@ def test_date_object():
     regular_freezer = freeze_time('2012-11-10')
     assert date_freezer.time_to_freeze == regular_freezer.time_to_freeze
 
+def test_old_date_object():
+    frozen_date = datetime.date(year=1, month=1, day=1)
+    with freeze_time(frozen_date):
+        assert datetime.date.today() == frozen_date
+
 def test_date_with_locale():
     with temp_locale(*_dd_mm_yyyy_locales):
         frozen_date = datetime.date(year=2012, month=1, day=2)
@@ -204,6 +209,12 @@ def test_datetime_object():
     datetime_freezer = freeze_time(frozen_datetime)
     regular_freezer = freeze_time('2012-11-10 04:15:30')
     assert datetime_freezer.time_to_freeze == regular_freezer.time_to_freeze
+
+def test_old_datetime_object():
+    frozen_datetime = datetime.datetime(year=1, month=7, day=12,
+                                        hour=15, minute=6, second=3)
+    with freeze_time(frozen_datetime):
+        assert datetime.datetime.now() == frozen_datetime
 
 def test_datetime_with_locale():
     with temp_locale(*_dd_mm_yyyy_locales):


### PR DESCRIPTION
By converting date and datetime objects to isoformat and then using dateutil to
convert to datetime, this freeze_time becomes exposed to more bugs in dateutil
than strictly necessary. I have found when using hypothesis-datetime to test my
own libraries in combination with freeze_gun that years earlier than 100 cause
bugs due to dateutil interpreting them as being in the 20th or 21st centuries.

This bug is avoided by simply preserving the date or datetime rather than
serializing and deserializing it.