### PR TITLE
Improve memory usage: forget about undo_changes after they are undone

### DIFF
--- a/freezegun/api.py
+++ b/freezegun/api.py
@@ -351,6 +351,7 @@ class _freeze_time(object):
             copyreg.dispatch_table.pop(real_date)
             for module, module_attribute, original_value in self.undo_changes:
                 setattr(module, module_attribute, original_value)
+            self.undo_changes = []
 
         time.time = time.time.previous_time_function
         time.gmtime = time.gmtime.previous_gmtime_function


### PR DESCRIPTION
List of 1000s of 3-tuples * many uses in tests = high memory use  :(

Also repeat use of the same `_freeze_time` object would continue adding to the existing list and then do multiple times the work necessary on `stop()`.