### PR TITLE
Decorate TestCase subclasses better

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,14 @@ Decorator
     def test():
         assert datetime.datetime.now() == datetime.datetime(2012, 01, 14)
 
-    # Or class based
+    # Or a unittest TestCase - freezes for every test, from the start of setUpClass to the end of tearDownClass
+
+    @freeze_time("1955-11-12")
+    class MyTests(unittest.TestCase):
+        def test_the_class(self):
+            assert datetime.datetime.now() == datetime.datetime(2012, 01, 14)
+
+    # Or any other class - freezes around each callable (may not work in every case)
 
     @freeze_time("2012-01-14")
     class Tester(object):


### PR DESCRIPTION
So the existing class decoration code is very surprising - by walking the MRO tree and decorating all the methods, every subclass of the superclasses is affected. This means that e.g. `unittest.TestCase` *itself* is mutated, which means that innocent users decorating one `TestCase` get *all* their tests frozen in one time. We've had some surprising at-a-distance breakages in our code base with class-based decoration and had to outlaw it until I had some time to figure it out.

The 'correct' way to do is as attached - subclass the given `TestCase` class and just `start()` the `freeze_time` once at the start of `setUpClass` and `stop()` it on `tearDownClass`. This is also faster since the full every-attribute-on-every-module sweep is only done once.

All the existing tests passed for this - mostly because on the TestCase classes, every test of course occurs between `setUpClass` and `tearDownClass`. I've also been using a similar workaround for my own codebase.

There *could* be some *slightly* surprising effects for users who are making `TestCase` subclasses and then calling methods on them in a weird way outside of `setUpClass` and `tearDownClass`, but I don't think that's worth worrying about compared to the surprising breakage the original implementation could cause, as it did for me.

I've left the original class decoration code, weird as it is, applicable to classes that don't subclass `unittest.TestCase`. I don't actually think anyone using it exactly *means* what it does though.