### PR TITLE
Allow arguments to nose to be passed through tox

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ init:
 
 test:
 	rm -f .coverage
-	nosetests ./tests/
+	nosetests $(NOSE_ARGS) ./tests/
 
 travis:
 	nosetests --with-coverage ./tests/

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@
 envlist = py26, py27, pypy, py32, py33, py34, pypy3
 
 [testenv]
-commands = make test
+commands = make test NOSE_ARGS="{posargs}"
 whitelist_externals = make
 deps =
     nose


### PR DESCRIPTION
Can be used like e.g. `tox -- -vv`, useful for advanced testing.