### PR TITLE
Add manual time increment (as a more controlled alternative to `tick=True`)

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -12,3 +12,4 @@ Patches and Suggestions
 - `Jesse London <https://github.com/jesteria>`_
 - `Zach Smith <https://github.com/zmsmith>`_
 - `Adam Johnson <https://github.com/adamchainz>`_
+- `Alex Ehlke <https://github.com/aehlke>`_

--- a/freezegun/api.py
+++ b/freezegun/api.py
@@ -254,6 +254,9 @@ class FrozenDateTimeFactory(object):
     def __call__(self):
         return self.time_to_freeze
 
+    def tick(self, delta=datetime.timedelta(seconds=1)):
+        self.time_to_freeze += delta
+
 
 class _freeze_time(object):
 
@@ -323,13 +326,12 @@ class _freeze_time(object):
             return klass
 
     def __enter__(self):
-        self.start()
+        return self.start()
 
     def __exit__(self, *args):
         self.stop()
 
     def start(self):
-
         if self.tick:
             time_to_freeze = TickingDateTimeFactory(self.time_to_freeze, real_datetime.now())
         else:
@@ -408,6 +410,8 @@ class _freeze_time(object):
 
         datetime.date.dates_to_freeze.append(time_to_freeze)
         datetime.date.tz_offsets.append(self.tz_offset)
+
+        return time_to_freeze
 
     def stop(self):
         datetime.datetime.times_to_freeze.pop()

--- a/tests/test_datetimes.py
+++ b/tests/test_datetimes.py
@@ -122,6 +122,21 @@ def test_time_with_dst():
     freezer.stop()
 
 
+def test_manual_increment():
+    initial_datetime = datetime.datetime(year=1, month=7, day=12,
+                                        hour=15, minute=6, second=3)
+    with freeze_time(initial_datetime) as frozen_datetime:
+        assert frozen_datetime() == initial_datetime
+
+        frozen_datetime.tick()
+        initial_datetime += datetime.timedelta(seconds=1)
+        assert frozen_datetime() == initial_datetime
+
+        frozen_datetime.tick(delta=datetime.timedelta(seconds=10))
+        initial_datetime += datetime.timedelta(seconds=10)
+        assert frozen_datetime() == initial_datetime
+
+
 def test_bad_time_argument():
     try:
         freeze_time("2012-13-14", tz_offset=-4)


### PR DESCRIPTION
It's useful to be able to use a frozen time and easily up-tick it manually, only as desired. Adds an `increment` method to the time freezer that takes an optional delta (defaulting to 1 second).

An example use case: in a common MySQL config, timestamps lack sub-second precision. With this, tests that do not mock time introduce a race condition where a quick series of timestamps may have the same value, or may straddle two seconds depending on when the test is ran. In this case, `tick=True` wouldn't help. This gives a nice shortcut to control time but still allow it to flow forward without having to entirely re-freeze.