### PR TITLE
Catch TypeError when fetching attribute values

### DIFF
--- a/freezegun/api.py
+++ b/freezegun/api.py
@@ -376,7 +376,7 @@ class _freeze_time(object):
                     continue
                 try:
                     attribute_value = getattr(module, module_attribute)
-                except (ImportError, AttributeError):
+                except (ImportError, AttributeError, TypeError):
                     # For certain libraries, this can result in ImportError(_winreg) or AttributeError (celery)
                     continue
                 try:


### PR DESCRIPTION
On the latest cryptography 1.2 we started getting TypeError here.
Apparently one of the values when iterating dir(module) is a number and not a string :S