### PR TITLE
Wrap dir(module) in try-except block.

### DIFF
--- a/freezegun/api.py
+++ b/freezegun/api.py
@@ -372,7 +372,11 @@ class _freeze_time(object):
                 continue
             elif (not hasattr(module, "__name__") or module.__name__ in ('datetime', 'time')):
                 continue
-            for module_attribute in dir(module):
+            try:
+                module_attributes = dir(module)
+            except TypeError:
+                continue
+            for module_attribute in module_attributes:
                 if module_attribute in real_names:
                     continue
                 try:


### PR DESCRIPTION
To prevent modules with incomparable keys from breaking freezegun
patching.

Fixes #126.