### PR TITLE
Respect System Timezone

### DIFF
--- a/freezegun/api.py
+++ b/freezegun/api.py
@@ -9,6 +9,8 @@ import platform
 
 from dateutil import parser
 
+system_tz_offset = (time.timezone if time.localtime().tm_isdst is 0 else time.altzone) / 60 / 60 * -1
+
 real_time = time.time
 real_localtime = time.localtime
 real_gmtime = time.gmtime
@@ -126,6 +128,9 @@ class FakeDate(with_metaclass(FakeDateMeta, real_date)):
     @classmethod
     def today(cls):
         result = cls._date_to_freeze() + datetime.timedelta(hours=cls._tz_offset())
+        # hack that we set it here :-/
+        if system_tz_offset:
+            result += datetime.timedelta(hours=system_tz_offset)
         return date_to_fakedate(result)
 
     @classmethod
@@ -177,6 +182,9 @@ class FakeDatetime(with_metaclass(FakeDatetimeMeta, real_datetime, FakeDate)):
             result = tz.fromutc(cls._time_to_freeze().replace(tzinfo=tz)) + datetime.timedelta(hours=cls._tz_offset())
         else:
             result = cls._time_to_freeze() + datetime.timedelta(hours=cls._tz_offset())
+            # hack that we set it here :-/
+            if system_tz_offset:
+                result += datetime.timedelta(hours=system_tz_offset)
         return datetime_to_fakedatetime(result)
 
     def date(self):
@@ -207,6 +215,8 @@ def convert_to_timezone_naive(time_to_freeze):
     """
     Converts a potentially timezone-aware datetime to be a naive UTC datetime
     """
+    if system_tz_offset:
+        time_to_freeze -= datetime.timedelta(hours=system_tz_offset)
     if time_to_freeze.tzinfo:
         time_to_freeze -= time_to_freeze.utcoffset()
         time_to_freeze = time_to_freeze.replace(tzinfo=None)


### PR DESCRIPTION
This fails a ton of built in tests - not sure anyway wants to use it or do the work to make tests pass.

It works for us though - we're forking it internally - thought maybe someone else could find it useful? We're using Django which patches the system TZ. Googlers - I hope you find out why your freezegun is working incorrectly or showing the wrong time with Django!

Here is an example of a test that worked for us:

```python
import pytz
import time
from datetime import datetime, date

from django.test import TestCase

from freezegun import freeze_time


class FreezeTimeOverrideTest(TestCase):
    def test_now_with_utc_dance(self):
        now = datetime.now()

        time_time = int(time.time())
        time_localtime = time.localtime()
        time_gmtime = time.gmtime()
        date_today = date.today()
        datetime_now = now.replace(microsecond=0)
        datetime_now_pytz_UTC = datetime.now(pytz.UTC).replace(microsecond=0)
        datetime_utcnow = datetime.utcnow().replace(microsecond=0)
        datetime_now_pytz_timezone_America_Los_Angeles = datetime.now(pytz.timezone('America/Los_Angeles')).replace(microsecond=0)

        time.sleep(1.2)
        # CST from django system override
        freeze_now = now.replace(microsecond=0).isoformat()
        del now

        with freeze_time(freeze_now):
            self.assertEquals(
                int(time.time()),
                time_time
            )
            self.assertEquals(
                list(time.localtime())[:-1], # isdst is wrong...
                list(time_localtime)[:-1] # isdst is wrong...
            )
            self.assertEquals(
                list(time.gmtime())[:-1], # isdst is wrong...
                list(time_gmtime)[:-1] # isdst is wrong...
            )
            self.assertEquals(
                date.today(),
                date_today
            )
            self.assertEquals(
                datetime.now().replace(microsecond=0),
                datetime_now
            )
            self.assertEquals(
                datetime.now(pytz.UTC).replace(microsecond=0),
                datetime_now_pytz_UTC
            )
            self.assertEquals(
                datetime.utcnow().replace(microsecond=0),
                datetime_utcnow
            )
            self.assertEquals(
                datetime.now(pytz.timezone('America/Los_Angeles')).replace(microsecond=0),
                datetime_now_pytz_timezone_America_Los_Angeles
            )
```