### PR TITLE
Globally exclude __pycache__ and py[co] from sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,4 @@
 include README.rst LICENSE AUTHORS.rst
 recursive-include tests *
+global-exclude __pycache__
+global-exclude *.py[co]


### PR DESCRIPTION
This change adds two global exclude patterns to `MANIFEST.in`, to preclude compiled/binary files from being added to the PyPI source distribution (sdist)

This change was tested to confirm the non-presence of these files in a newly generated sdist, by creating a new sdist using `python setup.py sdist`, using the sources from the existing tarball (that contain the bad files).

Resolves https://github.com/spulec/freezegun/issues/134

