### PR TITLE
Fixing halfdone work using None parameter for freeze_time()

### DIFF
--- a/freezegun/api.py
+++ b/freezegun/api.py
@@ -244,7 +244,8 @@ def _parse_time_to_freeze(time_to_freeze_str):
     :returns: a naive ``datetime.datetime`` object
     """
     if time_to_freeze_str is None:
-        time_to_freeze = datetime.datetime.utcnow()
+        time_to_freeze_str = datetime.datetime.utcnow()
+
     if isinstance(time_to_freeze_str, datetime.datetime):
         time_to_freeze = time_to_freeze_str
     elif isinstance(time_to_freeze_str, datetime.date):
@@ -482,7 +483,7 @@ def freeze_time(time_to_freeze=None, tz_offset=0, ignore=None, tick=False):
     except NameError:
         string_type = str
 
-    if not isinstance(time_to_freeze, (string_type, datetime.date)):
+    if not isinstance(time_to_freeze, (type(None), string_type, datetime.date)):
         raise TypeError(('freeze_time() expected None, a string, date instance, or '
                          'datetime instance, but got type {0}.').format(type(time_to_freeze)))
     if tick and not _is_cpython:

--- a/tests/test_class_import.py
+++ b/tests/test_class_import.py
@@ -144,3 +144,9 @@ def test_import_after_start():
     assert another_module.get_fake_localtime() is FakeLocalTime
     assert another_module.get_fake_gmtime() is FakeGMTTime
     assert another_module.get_fake_strftime() is FakeStrfTime
+
+
+def test_none_as_initial():
+    with freeze_time() as ft:
+        ft.move_to('2012-01-14')
+        assert fake_strftime_function() == '2012'


### PR DESCRIPTION
This is a small fix to support using `None` as the input-parameter for freeze_time(). This is very useful if you are moving time a lot, but don't care about the initial time.