### PR TITLE
Set default tz=None to astimezone method

### DIFF
--- a/freezegun/api.py
+++ b/freezegun/api.py
@@ -169,7 +169,7 @@ class FakeDatetime(with_metaclass(FakeDatetimeMeta, real_datetime, FakeDate)):
         else:
             return result
 
-    def astimezone(self, tz):
+    def astimezone(self, tz=None):
         if tz is None:
             tz = tzlocal()
         return datetime_to_fakedatetime(real_datetime.astimezone(self, tz))

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -78,6 +78,13 @@ def test_astimezone():
 
 
 @freeze_time("2012-01-14 00:00:00")
+def test_astimezone_tz_none():
+    now = datetime.datetime.now(tz=GMT5())
+    converted = now.astimezone()
+    assert utils.is_fake_datetime(converted)
+
+
+@freeze_time("2012-01-14 00:00:00")
 def test_replace():
     now = datetime.datetime.now()
     modified_time = now.replace(year=2013)


### PR DESCRIPTION
I want to use astimezone() with no argument.