### PR TITLE
Register fake types in PyMySQL conversions

### DIFF
--- a/freezegun/api.py
+++ b/freezegun/api.py
@@ -523,4 +523,6 @@ except ImportError:
     pass
 else:
     pymysql.converters.encoders[FakeDate] = pymysql.converters.encoders[real_date]
+    pymysql.converters.conversions[FakeDate] = pymysql.converters.encoders[real_date]
     pymysql.converters.encoders[FakeDatetime] = pymysql.converters.encoders[real_datetime]
+    pymysql.converters.conversions[FakeDatetime] = pymysql.converters.encoders[real_datetime]


### PR DESCRIPTION
PyMySQL creates the `conversion` object as a copy of the `encoders` object, so we need to register the type there as well. `Connection` for one uses `conversion`, so without this registration most SQL operations will fail.

Cf. https://github.com/PyMySQL/PyMySQL/blob/master/pymysql/converters.py#L417