### PR TITLE
Fix test to work when current timezone is GMT-14 or GMT+14.

### DIFF
--- a/tests/test_class_import.py
+++ b/tests/test_class_import.py
@@ -80,7 +80,8 @@ def test_import_localtime():
     struct = fake_localtime_function()
     assert struct.tm_year == 2012
     assert struct.tm_mon == 1
-    assert struct.tm_mday == 14
+    assert struct.tm_mday >= 13  # eg. GMT+14
+    assert struct.tm_mday <= 15  # eg. GMT-14
 
 
 @freeze_time("2012-01-14 12:00:00")


### PR DESCRIPTION
Wikipedia says that UTC+14 is a thing. /usr/share/zoneinfo says that
GMT-14 is a thing. Ensure both of them work in tests when using local
time. Python accepts up to a whole day (so, GMT+23 is valid). Fix the
test on local time to accept all that.

Fix #157.
