### PR TITLE
Fixed #162 - allow decorating old-style classes.

### DIFF
--- a/freezegun/api.py
+++ b/freezegun/api.py
@@ -329,7 +329,9 @@ class _freeze_time(object):
         else:
 
             seen = set()
-            for base_klass in klass.mro():
+
+            klasses = klass.mro() if hasattr(klass, 'mro') else [klass] + list(klass.__bases__)
+            for base_klass in klasses:
                 for (attr, attr_value) in base_klass.__dict__.items():
                     if attr.startswith('_') or attr in seen:
                         continue

--- a/tests/test_datetimes.py
+++ b/tests/test_datetimes.py
@@ -458,6 +458,28 @@ class FrozenInheritedTests(BaseInheritanceFreezableTests):
         self.assertEqual(datetime.date(2013, 4, 9), datetime.date.today())
 
 
+class TestOldStyleClasses:
+    def test_direct_method(self):
+        # Make sure old style classes (not inheriting from object) is supported
+        @freeze_time('2013-04-09')
+        class OldStyleClass:
+            def method(self):
+                return datetime.date.today()
+
+        assert OldStyleClass().method() == datetime.date(2013, 4, 9)
+
+    def test_inherited_method(self):
+        class OldStyleBaseClass:
+            def inherited_method(self):
+                return datetime.date.today()
+
+        @freeze_time('2013-04-09')
+        class OldStyleClass(OldStyleBaseClass):
+            pass
+
+        assert OldStyleClass().inherited_method() == datetime.date(2013, 4, 9)
+
+
 def test_min_and_max():
     freezer = freeze_time("2012-01-14")
     real_datetime = datetime.datetime


### PR DESCRIPTION
See #162 for more information. This commit fixes a regression which broke support for python 2 old-style classes.
