### PR TITLE
Add monkey-patching to the uuid module (uuid1)

### DIFF
--- a/freezegun/api.py
+++ b/freezegun/api.py
@@ -3,6 +3,7 @@ import functools
 import inspect
 import sys
 import time
+import uuid
 import calendar
 import unittest
 import platform
@@ -17,6 +18,16 @@ real_gmtime = time.gmtime
 real_strftime = time.strftime
 real_date = datetime.date
 real_datetime = datetime.datetime
+
+try:
+    real_uuid_generate_time = uuid._uuid_generate_time
+except ImportError:
+    real_uuid_generate_time = None
+
+try:
+    real_uuid_create = uuid._UuidCreate
+except ImportError:
+    real_uuid_create = None
 
 try:
     import copy_reg as copyreg
@@ -373,6 +384,8 @@ class _freeze_time(object):
         time.localtime = fake_localtime
         time.gmtime = fake_gmtime
         time.strftime = fake_strftime
+        uuid._uuid_generate_time = None
+        uuid._UuidCreate = None
 
         copyreg.dispatch_table[real_datetime] = pickle_fake_datetime
         copyreg.dispatch_table[real_date] = pickle_fake_date
@@ -472,6 +485,9 @@ class _freeze_time(object):
         time.gmtime = time.gmtime.previous_gmtime_function
         time.localtime = time.localtime.previous_localtime_function
         time.strftime = time.strftime.previous_strftime_function
+
+        uuid._uuid_generate_time = real_uuid_generate_time
+        uuid._UuidCreate = real_uuid_create
 
     def decorate_callable(self, func):
         def wrapper(*args, **kwargs):

--- a/tests/test_uuid.py
+++ b/tests/test_uuid.py
@@ -1,0 +1,24 @@
+import datetime
+import uuid
+
+from freezegun import freeze_time
+
+
+def time_from_uuid(value):
+    """Converts an UUID(1) to it's datetime value"""
+    uvalue = value if isinstance(value, uuid.UUID) else uuid.UUID(value)
+
+    assert uvalue.version == 1
+
+    return (datetime.datetime(1582, 10, 15) +
+            datetime.timedelta(microseconds=uvalue.time // 10))
+
+def test_uuid1():
+    # Test that the uuid.uuid1() methods generate a value from the freezed date
+    # This was not always the case as python is
+    # using the system's one if available through ctypes
+    target = datetime.datetime(2017, 2, 6, 14, 8, 21)
+
+    with freeze_time(target):
+        assert time_from_uuid(uuid.uuid1()) == target
+


### PR DESCRIPTION
The uuid.uuid1() method is using the time() function, but is not
consistent on every platform since it **may** use the ctypes methods if
available.

"Fix" this by patching the uuid module internal references so it will
always use the python version, thus making uuid1() method always return
the uuid from the frozen date