### PR TITLE
Fix ignored modules

### DIFF
--- a/freezegun/api.py
+++ b/freezegun/api.py
@@ -414,7 +414,7 @@ class _freeze_time(object):
             for mod_name, module in list(sys.modules.items()):
                 if mod_name is None or module is None:
                     continue
-                elif mod_name.startswith(self.ignore):
+                elif any(map(mod_name.startswith, self.ignore)):
                     continue
                 elif (not hasattr(module, "__name__") or module.__name__ in ('datetime', 'time')):
                     continue
@@ -463,7 +463,7 @@ class _freeze_time(object):
                     module = sys.modules.get(mod_name, None)
                     if mod_name is None or module is None:
                         continue
-                    elif mod_name.startswith(self.ignore):
+                    elif any(map(mod_name.startswith, self.ignore)):
                         continue
                     elif (not hasattr(module, "__name__") or module.__name__ in ('datetime', 'time')):
                         continue


### PR DESCRIPTION
A check was made for each module if its name starts with the ignore
tuple. No string ever starts with a tuple. Now it is checked for every
value inside of the ignore tuple if the module name starts with this
value.