### PR TITLE
Add google.gax to default ignore list

### DIFF
--- a/freezegun/api.py
+++ b/freezegun/api.py
@@ -520,6 +520,7 @@ def freeze_time(time_to_freeze=None, tz_offset=0, ignore=None, tick=False):
         ignore = []
     ignore.append('six.moves')
     ignore.append('django.utils.six.moves')
+    ignore.append('google.gax')
     ignore.append('threading')
     ignore.append('Queue')
     return _freeze_time(time_to_freeze, tz_offset, ignore, tick)


### PR DESCRIPTION
google.gax depends on time.time() for communicating with external
systems. This is supposed to fix issues similar to
https://github.com/GoogleCloudPlatform/google-cloud-python/issues/3284