### PR TITLE
Handling functions and generator objects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -93,10 +93,10 @@ FreezeGun uses dateutil behind the scenes so you can have nice-looking datetimes
     def test_nice_datetime():
         assert datetime.datetime.now() == datetime.datetime(2012, 1, 14)
 
-Function objects
-~~~~~~~~~~~~~~~~
+Function and generator objects
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-FreezeGun is able to handle function objects.
+FreezeGun is able to handle function and generator objects.
 
 .. code-block:: python
 
@@ -104,6 +104,16 @@ FreezeGun is able to handle function objects.
         with freeze_time(lambda: datetime.datetime(2012, 1, 14)):
             assert datetime.datetime.now() == datetime.datetime(2012, 1, 14)
 
+    def test_generator():
+        datetimes = (datetime.datetime(year, 1, 1) for year in range(2010, 2012))
+
+        with freeze_time(datetimes):
+            assert datetime.datetime.now() == datetime.datetime(2010, 1, 1)
+
+        with freeze_time(datetimes):
+            assert datetime.datetime.now() == datetime.datetime(2011, 1, 1)
+
+        # The next call to freeze_time(datetimes) would raise a StopIteration exception.
 
 ``tick`` argument
 ~~~~~~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -93,6 +93,18 @@ FreezeGun uses dateutil behind the scenes so you can have nice-looking datetimes
     def test_nice_datetime():
         assert datetime.datetime.now() == datetime.datetime(2012, 1, 14)
 
+Function objects
+~~~~~~~~~~~~~~~~
+
+FreezeGun is able to handle function objects.
+
+.. code-block:: python
+
+    def test_lambda():
+        with freeze_time(lambda: datetime.datetime(2012, 1, 14)):
+            assert datetime.datetime.now() == datetime.datetime(2012, 1, 14)
+
+
 ``tick`` argument
 ~~~~~~~~~~~~~~~~~
 

--- a/freezegun/api.py
+++ b/freezegun/api.py
@@ -8,6 +8,7 @@ import calendar
 import unittest
 import platform
 import warnings
+import types
 
 from dateutil import parser
 from dateutil.tz import tzlocal
@@ -510,11 +511,14 @@ def freeze_time(time_to_freeze=None, tz_offset=0, ignore=None, tick=False):
     except NameError:
         string_type = str
 
-    if not isinstance(time_to_freeze, (type(None), string_type, datetime.date)):
-        raise TypeError(('freeze_time() expected None, a string, date instance, or '
-                         'datetime instance, but got type {0}.').format(type(time_to_freeze)))
+    if not isinstance(time_to_freeze, (type(None), string_type, datetime.date, types.FunctionType)):
+        raise TypeError(('freeze_time() expected None, a string, date instance, datetime '
+                         'instance or a function, but got type {0}.').format(type(time_to_freeze)))
     if tick and not _is_cpython:
         raise SystemError('Calling freeze_time with tick=True is only compatible with CPython')
+
+    if isinstance(time_to_freeze, types.FunctionType):
+        return freeze_time(time_to_freeze(), tz_offset, ignore, tick)
 
     if ignore is None:
         ignore = []

--- a/freezegun/api.py
+++ b/freezegun/api.py
@@ -511,14 +511,18 @@ def freeze_time(time_to_freeze=None, tz_offset=0, ignore=None, tick=False):
     except NameError:
         string_type = str
 
-    if not isinstance(time_to_freeze, (type(None), string_type, datetime.date, types.FunctionType)):
+    if not isinstance(time_to_freeze, (type(None), string_type, datetime.date,
+        types.FunctionType, types.GeneratorType)):
         raise TypeError(('freeze_time() expected None, a string, date instance, datetime '
-                         'instance or a function, but got type {0}.').format(type(time_to_freeze)))
+                         'instance, function or a generator, but got type {0}.').format(type(time_to_freeze)))
     if tick and not _is_cpython:
         raise SystemError('Calling freeze_time with tick=True is only compatible with CPython')
 
     if isinstance(time_to_freeze, types.FunctionType):
         return freeze_time(time_to_freeze(), tz_offset, ignore, tick)
+
+    if isinstance(time_to_freeze, types.GeneratorType):
+        return freeze_time(next(time_to_freeze), tz_offset, ignore, tick)
 
     if ignore is None:
         ignore = []

--- a/tests/test_datetimes.py
+++ b/tests/test_datetimes.py
@@ -5,6 +5,7 @@ import locale
 import sys
 
 from nose.plugins import skip
+from nose.tools import assert_raises
 from tests import utils
 
 from freezegun import freeze_time
@@ -262,6 +263,19 @@ def test_lambda_object():
                                         hour=4, minute=15, second=30)
     with freeze_time(lambda: frozen_datetime):
         assert frozen_datetime == datetime.datetime.now()
+
+
+def test_generator_object():
+    frozen_datetimes = (datetime.datetime(year=y, month=1, day=1)
+        for y in range(2010, 2012))
+
+    with freeze_time(frozen_datetimes):
+        assert datetime.datetime(2010, 1, 1) == datetime.datetime.now()
+
+    with freeze_time(frozen_datetimes):
+        assert datetime.datetime(2011, 1, 1) == datetime.datetime.now()
+
+    assert_raises(StopIteration, freeze_time, frozen_datetimes)
 
 
 def test_old_datetime_object():

--- a/tests/test_datetimes.py
+++ b/tests/test_datetimes.py
@@ -248,6 +248,22 @@ def test_datetime_object():
     assert datetime_freezer.time_to_freeze == regular_freezer.time_to_freeze
 
 
+def test_function_object():
+    frozen_datetime = datetime.datetime(year=2012, month=11, day=10,
+                                        hour=4, minute=15, second=30)
+    def function(): return frozen_datetime
+
+    with freeze_time(function):
+        assert frozen_datetime == datetime.datetime.now()
+
+
+def test_lambda_object():
+    frozen_datetime = datetime.datetime(year=2012, month=11, day=10,
+                                        hour=4, minute=15, second=30)
+    with freeze_time(lambda: frozen_datetime):
+        assert frozen_datetime == datetime.datetime.now()
+
+
 def test_old_datetime_object():
     frozen_datetime = datetime.datetime(year=1, month=7, day=12,
                                         hour=15, minute=6, second=3)


### PR DESCRIPTION
As mentioned in #182, this PR allow to use functions and generators with `freeze_time()`. So now the next pieces of code are valid:
```python
def test_lambda():
    with freeze_time(lambda: datetime.datetime(2012, 1, 14)):
        assert datetime.datetime.now() == datetime.datetime(2012, 1, 14)

def test_generator():
    datetimes = (datetime.datetime(year, 1, 1) for year in range(2010, 2012))

    with freeze_time(datetimes):
        assert datetime.datetime.now() == datetime.datetime(2010, 1, 1)

    with freeze_time(datetimes):
        assert datetime.datetime.now() == datetime.datetime(2011, 1, 1)

    # The next call to freeze_time(datetimes) would raise a StopIteration exception.
```
The generator part of this PR is mostly sugar, as we could manage to have the same behavior using lambdas, for example with `freeze_time(lambda: next(my_generator))` instead of `freeze_time(my_generator)`.