### PR TITLE
Split datetimes generator to a new function: freeze_times

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -93,10 +93,10 @@ FreezeGun uses dateutil behind the scenes so you can have nice-looking datetimes
     def test_nice_datetime():
         assert datetime.datetime.now() == datetime.datetime(2012, 1, 14)
 
-Function and generator objects
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Function
+~~~~~~~~
 
-FreezeGun is able to handle function and generator objects.
+FreezeGun is able to handle function to get date to freeze.
 
 .. code-block:: python
 
@@ -104,16 +104,23 @@ FreezeGun is able to handle function and generator objects.
         with freeze_time(lambda: datetime.datetime(2012, 1, 14)):
             assert datetime.datetime.now() == datetime.datetime(2012, 1, 14)
 
+Generator
+~~~~~~~~~
+
+FreezeGun is able to handle generator to get several different dates.
+
+.. code-block:: python
+
     def test_generator():
         datetimes = (datetime.datetime(year, 1, 1) for year in range(2010, 2012))
 
-        with freeze_time(datetimes):
+        with freeze_times(datetimes):
             assert datetime.datetime.now() == datetime.datetime(2010, 1, 1)
 
-        with freeze_time(datetimes):
+        with freeze_times(datetimes):
             assert datetime.datetime.now() == datetime.datetime(2011, 1, 1)
 
-        # The next call to freeze_time(datetimes) would raise a StopIteration exception.
+        # The next call to freeze_times(datetimes) would raise a StopIteration exception.
 
 ``tick`` argument
 ~~~~~~~~~~~~~~~~~

--- a/freezegun/__init__.py
+++ b/freezegun/__init__.py
@@ -6,7 +6,7 @@ freezegun
 :copyright: (c) 2012 by Steve Pulec.
 
 """
-from .api import freeze_time
+from .api import freeze_time, freeze_times
 
 __title__ = 'freezegun'
 __version__ = '0.3.9'

--- a/freezegun/api.py
+++ b/freezegun/api.py
@@ -514,15 +514,12 @@ def freeze_time(time_to_freeze=None, tz_offset=0, ignore=None, tick=False):
     if not isinstance(time_to_freeze, (type(None), string_type, datetime.date,
         types.FunctionType, types.GeneratorType)):
         raise TypeError(('freeze_time() expected None, a string, date instance, datetime '
-                         'instance, function or a generator, but got type {0}.').format(type(time_to_freeze)))
+                         'instance or function, but got type {0}.').format(type(time_to_freeze)))
     if tick and not _is_cpython:
         raise SystemError('Calling freeze_time with tick=True is only compatible with CPython')
 
     if isinstance(time_to_freeze, types.FunctionType):
         return freeze_time(time_to_freeze(), tz_offset, ignore, tick)
-
-    if isinstance(time_to_freeze, types.GeneratorType):
-        return freeze_time(next(time_to_freeze), tz_offset, ignore, tick)
 
     if ignore is None:
         ignore = []
@@ -531,6 +528,13 @@ def freeze_time(time_to_freeze=None, tz_offset=0, ignore=None, tick=False):
     ignore.append('threading')
     ignore.append('Queue')
     return _freeze_time(time_to_freeze, tz_offset, ignore, tick)
+
+
+def freeze_times(time_to_freeze=None, tz_offset=0, ignore=None, tick=False):
+    if not isinstance(time_to_freeze, types.GeneratorType):
+        raise TypeError(('freeze_times() expected a generator, but got type {0}.').format(type(time_to_freeze)))
+
+    return freeze_time(next(time_to_freeze), tz_offset, ignore, tick)
 
 
 # Setup adapters for sqlite

--- a/tests/test_datetimes.py
+++ b/tests/test_datetimes.py
@@ -8,7 +8,7 @@ from nose.plugins import skip
 from nose.tools import assert_raises
 from tests import utils
 
-from freezegun import freeze_time
+from freezegun import freeze_time, freeze_times
 from freezegun.api import FakeDatetime, FakeDate
 
 
@@ -269,13 +269,13 @@ def test_generator_object():
     frozen_datetimes = (datetime.datetime(year=y, month=1, day=1)
         for y in range(2010, 2012))
 
-    with freeze_time(frozen_datetimes):
+    with freeze_times(frozen_datetimes):
         assert datetime.datetime(2010, 1, 1) == datetime.datetime.now()
 
-    with freeze_time(frozen_datetimes):
+    with freeze_times(frozen_datetimes):
         assert datetime.datetime(2011, 1, 1) == datetime.datetime.now()
 
-    assert_raises(StopIteration, freeze_time, frozen_datetimes)
+    assert_raises(StopIteration, freeze_times, frozen_datetimes)
 
 
 def test_old_datetime_object():


### PR DESCRIPTION
Perhaps it's better to limit the accepted parameter to freeze_time() to one element parameter (a string, a datetime, etc.) and when several elements are provided, use another function. I called it freeze_times(). 

The patch move the code of the generator to this new function.

However, it adds a second function into the API so you could consider it's more complicated for the user. 