### PR TITLE
Set uuid._last_timestamp=None to reset uiud1() when enter/exit context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ build
 *.tox
 dist
 *.pyc
+venv/
+.idea

--- a/freezegun/api.py
+++ b/freezegun/api.py
@@ -391,6 +391,7 @@ class _freeze_time(object):
         time.strftime = fake_strftime
         uuid._uuid_generate_time = None
         uuid._UuidCreate = None
+        uuid._last_timestamp = None
 
         copyreg.dispatch_table[real_datetime] = pickle_fake_datetime
         copyreg.dispatch_table[real_date] = pickle_fake_date
@@ -493,6 +494,7 @@ class _freeze_time(object):
 
         uuid._uuid_generate_time = real_uuid_generate_time
         uuid._UuidCreate = real_uuid_create
+        uuid._last_timestamp = None
 
     def decorate_callable(self, func):
         def wrapper(*args, **kwargs):

--- a/tests/test_uuid.py
+++ b/tests/test_uuid.py
@@ -1,24 +1,46 @@
+from __future__ import print_function, absolute_import, unicode_literals
 import datetime
 import uuid
+
+from nose.tools import assert_equal
 
 from freezegun import freeze_time
 
 
 def time_from_uuid(value):
-    """Converts an UUID(1) to it's datetime value"""
+    """
+    Converts an UUID(1) to it's datetime value
+    """
     uvalue = value if isinstance(value, uuid.UUID) else uuid.UUID(value)
-
     assert uvalue.version == 1
-
     return (datetime.datetime(1582, 10, 15) +
             datetime.timedelta(microseconds=uvalue.time // 10))
 
-def test_uuid1():
-    # Test that the uuid.uuid1() methods generate a value from the freezed date
-    # This was not always the case as python is
-    # using the system's one if available through ctypes
-    target = datetime.datetime(2017, 2, 6, 14, 8, 21)
 
-    with freeze_time(target):
-        assert time_from_uuid(uuid.uuid1()) == target
+def test_uuid1_future():
+    """
+    Test that we can go back in time after setting a future date.
+    Normally UUID1 would disallow this, since it keeps track of
+    the _last_timestamp, but we override that now.
+    """
+    future_target = datetime.datetime(2056, 2, 6, 14, 3, 21)
+    with freeze_time(future_target):
+        assert_equal(time_from_uuid(uuid.uuid1()), future_target)
 
+    past_target = datetime.datetime(1978, 7, 6, 23, 6, 31)
+    with freeze_time(past_target):
+        assert_equal(time_from_uuid(uuid.uuid1()), past_target)
+
+
+def test_uuid1_past():
+    """
+    Test that we can go forward in time after setting some time in the past.
+    This is simply the opposite of test_uuid1_future()
+    """
+    past_target = datetime.datetime(1978, 7, 6, 23, 6, 31)
+    with freeze_time(past_target):
+        assert_equal(time_from_uuid(uuid.uuid1()), past_target)
+
+    future_target = datetime.datetime(2056, 2, 6, 14, 3, 21)
+    with freeze_time(future_target):
+        assert_equal(time_from_uuid(uuid.uuid1()), future_target)


### PR DESCRIPTION
Applies to #196 