### PR TITLE
Allow timedeltas to be used for tz_offset

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -82,6 +82,10 @@ Timezones
         # datetime.date.today() uses local time
         assert datetime.date.today() == datetime.date(2012, 1, 13)
 
+    @freeze_time("2012-01-14 03:21:34", tz_offset=-datetime.timedelta(hours=3, minutes=30))
+    def test_timedelta_offset():
+        assert datetime.datetime.now() == datetime.datetime(2012, 1, 13, 23, 51, 34)
+
 Nice inputs
 ~~~~~~~~~~~
 

--- a/freezegun/api.py
+++ b/freezegun/api.py
@@ -140,7 +140,7 @@ class FakeDate(with_metaclass(FakeDateMeta, real_date)):
 
     @classmethod
     def today(cls):
-        result = cls._date_to_freeze() + datetime.timedelta(hours=cls._tz_offset())
+        result = cls._date_to_freeze() + cls._tz_offset()
         return date_to_fakedate(result)
 
     @classmethod
@@ -192,9 +192,9 @@ class FakeDatetime(with_metaclass(FakeDatetimeMeta, real_datetime, FakeDate)):
     def now(cls, tz=None):
         now = cls._time_to_freeze() or real_datetime.now()
         if tz:
-            result = tz.fromutc(now.replace(tzinfo=tz)) + datetime.timedelta(hours=cls._tz_offset())
+            result = tz.fromutc(now.replace(tzinfo=tz)) + cls._tz_offset()
         else:
-            result = now + datetime.timedelta(hours=cls._tz_offset())
+            result = now + cls._tz_offset()
         return datetime_to_fakedatetime(result)
 
     def date(self):
@@ -272,6 +272,13 @@ def _parse_time_to_freeze(time_to_freeze_str):
     return convert_to_timezone_naive(time_to_freeze)
 
 
+def _parse_tz_offset(tz_offset):
+    if isinstance(tz_offset, datetime.timedelta):
+        return tz_offset
+    else:
+        return datetime.timedelta(hours=tz_offset)
+
+
 class TickingDateTimeFactory(object):
 
     def __init__(self, time_to_freeze, start):
@@ -308,7 +315,7 @@ class _freeze_time(object):
     def __init__(self, time_to_freeze_str, tz_offset, ignore, tick):
 
         self.time_to_freeze = _parse_time_to_freeze(time_to_freeze_str)
-        self.tz_offset = tz_offset
+        self.tz_offset = _parse_tz_offset(tz_offset)
         self.ignore = tuple(ignore)
         self.tick = tick
         self.undo_changes = []

--- a/tests/test_datetimes.py
+++ b/tests/test_datetimes.py
@@ -77,6 +77,15 @@ def test_tz_offset():
     freezer.stop()
 
 
+def test_timedelta_tz_offset():
+    freezer = freeze_time("2012-01-14 03:21:34",
+                          tz_offset=-datetime.timedelta(hours=3, minutes=30))
+    freezer.start()
+    assert datetime.datetime.now() == datetime.datetime(2012, 1, 13, 23, 51, 34)
+    assert datetime.datetime.utcnow() == datetime.datetime(2012, 1, 14, 3, 21, 34)
+    freezer.stop()
+
+
 def test_tz_offset_with_today():
     freezer = freeze_time("2012-01-14", tz_offset=-4)
     freezer.start()


### PR DESCRIPTION
This makes it easier to call `freeze_time` in a way that respects the existing `tzinfo` on the `datetime` object:

```python
freezegun.freeze_time(dt, tz_offset=dt.utcoffset())
```

It also improves handling of non-integer offsets like [Newfoundland Time Zone](https://en.wikipedia.org/wiki/Newfoundland_Time_Zone).  Using `tz_offset=3.5` currently works, but I'm always wary of rounding errors when it comes to floats.  With this change you can write:

```python
freeze_time("2012-01-14", tz_offset=-datetime.timedelta(hours=3, minutes=30))
```
