### PR TITLE
Add support for time.monotonic()

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ FreezeGun is a library that allows your python tests to travel through time by m
 Usage
 -----
 
-Once the decorator or context manager have been invoked, all calls to datetime.datetime.now(), datetime.datetime.utcnow(), datetime.date.today(), time.time(), time.localtime(), time.gmtime(), and time.strftime() will return the time that has been frozen.
+Once the decorator or context manager have been invoked, all calls to datetime.datetime.now(), datetime.datetime.utcnow(), datetime.date.today(), time.time(), time.localtime(), time.gmtime(), time.strftime() and time.monotonic() will return the time that has been frozen.
 
 Decorator
 ~~~~~~~~~
@@ -173,6 +173,7 @@ Freezegun allows moving time to specific dates.
 
 Parameter for ``move_to`` can be any valid ``freeze_time`` date (string, date, datetime).
 
+Note that for ``tick``, manual tick and ``move_to`` there is by default moved frozen time.monotonic(). If you need to turn this off just add ``'time.monotonic'`` to ``ignore`` parameter.
 
 Default Arguments
 ~~~~~~~~~~~~~~~~~

--- a/freezegun/api.py
+++ b/freezegun/api.py
@@ -422,7 +422,7 @@ class _freeze_time(object):
             ('real_strftime', real_strftime, 'FakeStrfTime', fake_strftime),
             ('real_time', real_time, 'FakeTime', fake_time),
         ]
-        if real_monotonic is not None:
+        if real_monotonic is not None and 'time.monotonic' not in self.ignore:
             fake_monotonic = FakeMonotonic(time_to_freeze, time.monotonic)
             time.monotonic = fake_monotonic
             to_patch.append(('real_monotonic', real_monotonic, 'FakeMonotonic', fake_monotonic))
@@ -449,6 +449,9 @@ class _freeze_time(object):
                 for module_attribute in dir(module):
                     if module_attribute in real_names:
                         continue
+                    if '{}.{}'.format(mod_name, module_attribute) in self.ignore:
+                        continue
+
                     try:
                         attribute_value = getattr(module, module_attribute)
                     except (ImportError, AttributeError, TypeError):
@@ -499,6 +502,9 @@ class _freeze_time(object):
 
                         if module_attribute in self.fake_names:
                             continue
+                        if '{}.{}'.format(mod_name, module_attribute) in self.ignore:
+                            continue
+
                         try:
                             attribute_value = getattr(module, module_attribute)
                         except (ImportError, AttributeError, TypeError):
@@ -513,7 +519,7 @@ class _freeze_time(object):
         time.gmtime = time.gmtime.previous_gmtime_function
         time.localtime = time.localtime.previous_localtime_function
         time.strftime = time.strftime.previous_strftime_function
-        if real_monotonic is not None:
+        if real_monotonic is not None and 'time.monotonic' not in self.ignore:
             time.monotonic = time.monotonic.previous_monotonic_function
 
         uuid._uuid_generate_time = real_uuid_generate_time

--- a/tests/test_datetimes.py
+++ b/tests/test_datetimes.py
@@ -206,6 +206,27 @@ def test_move_to_monotonic():
         assert time.monotonic() == initial_monotonic
 
 
+def test_monotonic_can_be_ignored():
+    if sys.version_info[0] != 3:
+        raise skip.SkipTest("test target is Python3")
+
+    initial_datetime = datetime.datetime(year=1, month=7, day=12,
+                                         hour=15, minute=6, second=3)
+
+    other_datetime = datetime.datetime(year=2, month=8, day=13,
+                                       hour=14, minute=5, second=0)
+    # time.monotonic() will not affected by freeze_time
+    with freeze_time(initial_datetime, ignore=['time.monotonic']) as frozen_datetime:
+        initial_monotonic = time.monotonic()
+
+        frozen_datetime.move_to(other_datetime)
+        second_monotonic = time.monotonic()
+        assert second_monotonic > initial_monotonic
+
+        frozen_datetime.move_to(initial_datetime)
+        assert time.monotonic() > second_monotonic
+
+
 def test_bad_time_argument():
     try:
         freeze_time("2012-13-14", tz_offset=-4)

--- a/tests/test_ticking.py
+++ b/tests/test_ticking.py
@@ -1,6 +1,9 @@
 import datetime
 import time
 import mock
+import sys
+
+from nose.plugins import skip
 
 from freezegun import freeze_time
 from tests import utils
@@ -43,3 +46,14 @@ def test_non_pypy_compat():
         freeze_time("Jan 14th, 2012, 23:59:59", tick=True)
     except Exception:
         raise AssertionError("tick=True should not error on CPython")
+
+
+@utils.cpython_only
+def test_ticking_datetime_monotonic():
+    if sys.version_info[0] != 3:
+        raise skip.SkipTest("test target is Python3")
+
+    with freeze_time("Jan 14th, 2012", tick=True):
+        initial_monotonic = time.monotonic()
+        time.sleep(0.001)  # Deal with potential clock resolution problems
+        assert time.monotonic() > initial_monotonic


### PR DESCRIPTION
Hello, for our testing purposes we needed `freezegun` to work also with `time.monotonic()` https://docs.python.org/3/library/time.html#time.monotonic . Specifically we need `asyncio`'s `call_later` function to work properly with frozen time. Our use case is as follows:
```python
import freezegun
async def consume(generator):
	with freezegun.freeze_time(None) as frozen_datetime:
		for message in generator:
			frozen_datetime.move_to(message.time)
			await process(message)      
```
So we need to have time frozen in `process`. But when in `process` is some `asyncio.call_later` it is called according to real time (`time.monotonic()`). To overcome this I have written this PR, that also patches `time.monotonic()` .
This works good for our purpose but there is a hidden catch: when you use `await asyncio.sleep(delta)` in `process()` it will hang indefinitely: it makes sense `time.monotonic` is stopped so it does not know how long it should wait. This might be surprising so I'm pointing this out if we want to have this behavior in `freezegun` by default or it should be an option to `freeze_time`. 
I need to sleep for a moment in that loop so scheduled coroutines have chance to process so I'm using this little hack:
```python
@contextlib.contextmanager
def freeze_sleep(frozen_datetime):

	original_asyncio_sleep = asyncio.sleep

	async def move_time(delta):
		frozen_datetime.tick(delta)

	async def freeze_sleep(delta):
		asyncio.ensure_future(move_time(delta))
		await original_asyncio_sleep(delta)

	asyncio.sleep = freeze_sleep

	yield

	asyncio.sleep = original_asyncio_sleep
```
That patches `asyncio.sleep` so it will perform but also will move `frozen_datetime` by time to sleep.
What do you think about this PR?