### PR TITLE
Added option to pass in the factory to a decorated class

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -171,6 +171,13 @@ Freezegun allows moving time to specific dates.
             frozen_datetime.move_to(initial_datetime)
             assert frozen_datetime() == initial_datetime
 
+
+    @freeze_time("2012-01-14", as_arg=True)
+    def test(frozen_time):
+        assert datetime.datetime.now() == datetime.datetime(2012, 1, 14)
+        frozen_time.move_to("2014-02-12")
+        assert datetime.datetime.now() == datetime.datetime(2014, 2, 12)
+
 Parameter for ``move_to`` can be any valid ``freeze_time`` date (string, date, datetime).
 
 


### PR DESCRIPTION
I have a few examples in the Moto project where we have the following code which will freeze time for the mocked moto service its wrapping.
```python
@freeze_time("2016-01-01")
@mock_someservice
def test_something():
    # Do some stuff
```
We could do with being able to advance time whilst in the test case. So the patch provides the following functionality whilst still remaining backwards compatible
```python
@freeze_time("2016-01-01", as_arg=True)
@mock_someservice
def test_something(frozen_time):
    # Do some stuff
    frozen_time.move_to("2016-02-01")
    # Do more stuff
```