### PR TITLE
Fix uuid patch when jumping back in time

### DIFF
--- a/freezegun/api.py
+++ b/freezegun/api.py
@@ -392,6 +392,7 @@ class _freeze_time(object):
         time.strftime = fake_strftime
         uuid._uuid_generate_time = None
         uuid._UuidCreate = None
+        uuid._last_timestamp = None
 
         copyreg.dispatch_table[real_datetime] = pickle_fake_datetime
         copyreg.dispatch_table[real_date] = pickle_fake_date
@@ -494,6 +495,7 @@ class _freeze_time(object):
 
         uuid._uuid_generate_time = real_uuid_generate_time
         uuid._UuidCreate = real_uuid_create
+        uuid._last_timestamp = None
 
     def decorate_callable(self, func):
         def wrapper(*args, **kwargs):

--- a/tests/test_uuid.py
+++ b/tests/test_uuid.py
@@ -22,3 +22,10 @@ def test_uuid1():
     with freeze_time(target):
         assert time_from_uuid(uuid.uuid1()) == target
 
+    # Furthermore, test that jumping back in time works with uuid genration
+    # (regression test: internal uuid variable would
+    # keep the time part to the most recent one)
+    back_target = datetime.datetime(2017, 2, 1)
+    with freeze_time(back_target):
+        assert time_from_uuid(uuid.uuid1()) == back_target
+


### PR DESCRIPTION
The uuid module keeps an internal variable as some kind of cache that
prevents jumping back in time: the most recent timestamp would always be
returned