### PR TITLE
Do not scan vendored copies of six.moves: Makes start faster

### DIFF
--- a/freezegun/api.py
+++ b/freezegun/api.py
@@ -420,7 +420,7 @@ class _freeze_time(object):
             for mod_name, module in list(sys.modules.items()):
                 if mod_name is None or module is None:
                     continue
-                elif mod_name.startswith(self.ignore):
+                elif mod_name.startswith(self.ignore) or mod_name.endswith('.six.moves'):
                     continue
                 elif (not hasattr(module, "__name__") or module.__name__ in ('datetime', 'time')):
                     continue

--- a/freezegun/api.py
+++ b/freezegun/api.py
@@ -535,7 +535,6 @@ def freeze_time(time_to_freeze=None, tz_offset=0, ignore=None, tick=False, as_ar
     if ignore is None:
         ignore = []
     ignore.append('six.moves')
-    ignore.append('django.utils.six.moves')
     ignore.append('threading')
     ignore.append('Queue')
     return _freeze_time(time_to_freeze, tz_offset, ignore, tick, as_arg)

--- a/freezegun/api.py
+++ b/freezegun/api.py
@@ -469,7 +469,7 @@ class _freeze_time(object):
                     module = sys.modules.get(mod_name, None)
                     if mod_name is None or module is None:
                         continue
-                    elif mod_name.startswith(self.ignore):
+                    elif mod_name.startswith(self.ignore) or mod_name.endswith('.six.moves'):
                         continue
                     elif (not hasattr(module, "__name__") or module.__name__ in ('datetime', 'time')):
                         continue


### PR DESCRIPTION
Skip modules that end with the name .six.moves since many libraries
include their own copy. This makes starting freezegun much faster.
Freezegun already skips the module named "six.moves" by appending
it to the freezer's "ignore" list. However, many libraries ship their
own copy, and import it under their own name. For example, in
pkg_resources:

    from pkg_resources.extern import six

A list of copies of six.py in a project I work on shows the following
libraries include a copy, so I suspect this is pretty common:

boto
pip
pkg_resources
urllib3