### PR TITLE
Asyncio/Coroutine support

### DIFF
--- a/freezegun/_async.py
+++ b/freezegun/_async.py
@@ -1,0 +1,17 @@
+import functools
+
+import asyncio
+
+
+def wrap_coroutine(api, coroutine):
+    @functools.wraps(coroutine)
+    @asyncio.coroutine
+    def wrapper(*args, **kwargs):
+        with api as time_factory:
+            if api.as_arg:
+                result = yield from coroutine(time_factory, *args, **kwargs)
+            else:
+                result = yield from coroutine(*args, **kwargs)
+        return result
+
+    return wrapper

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -1,6 +1,8 @@
 import datetime
 from textwrap import dedent
 
+from nose.plugins import skip
+
 from freezegun import freeze_time
 
 try:
@@ -9,19 +11,26 @@ except ImportError:
     asyncio = False
 
 
-if asyncio:
-    def test_time_freeze_coroutine():
-        @asyncio.coroutine
-        @freeze_time('1970-01-01')
-        def frozen_coroutine():
-            assert datetime.date.today() == datetime.date(1970, 1, 1)
+def test_time_freeze_coroutine():
+    if not asyncio:
+        raise skip.SkipTest('asyncio required')
+    @asyncio.coroutine
+    @freeze_time('1970-01-01')
+    def frozen_coroutine():
+        assert datetime.date.today() == datetime.date(1970, 1, 1)
 
-        asyncio.get_event_loop().run_until_complete(frozen_coroutine())
+    asyncio.get_event_loop().run_until_complete(frozen_coroutine())
 
-    exec(dedent('''
-    def test_time_freeze_async_def():
+
+def test_time_freeze_async_def():
+    try:
+        exec('async def foo(): pass')
+    except SyntaxError:
+        raise skip.SkipTest('async def not supported')
+    else:
+        exec(dedent('''
         @freeze_time('1970-01-01')
         async def frozen_coroutine():
             assert datetime.date.today() == datetime.date(1970, 1, 1)
         asyncio.get_event_loop().run_until_complete(frozen_coroutine())
-    '''))
+        '''))

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -1,4 +1,5 @@
 import datetime
+from textwrap import dedent
 
 from freezegun import freeze_time
 
@@ -10,8 +11,17 @@ except ImportError:
 
 if asyncio:
     def test_time_freeze_coroutine():
+        @asyncio.coroutine
         @freeze_time('1970-01-01')
-        async def frozen_coroutine():
+        def frozen_coroutine():
             assert datetime.date.today() == datetime.date(1970, 1, 1)
 
         asyncio.get_event_loop().run_until_complete(frozen_coroutine())
+
+    exec(dedent('''
+    def test_time_freeze_async_def():
+        @freeze_time('1970-01-01')
+        async def frozen_coroutine():
+            assert datetime.date.today() == datetime.date(1970, 1, 1)
+        asyncio.get_event_loop().run_until_complete(frozen_coroutine())
+    '''))

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -1,0 +1,17 @@
+import datetime
+
+from freezegun import freeze_time
+
+try:
+    import asyncio
+except ImportError:
+    asyncio = False
+
+
+if asyncio:
+    def test_time_freeze_coroutine():
+        @freeze_time('1970-01-01')
+        async def frozen_coroutine():
+            assert datetime.date.today() == datetime.date(1970, 1, 1)
+
+        asyncio.get_event_loop().run_until_complete(frozen_coroutine())


### PR DESCRIPTION
This patch fixes #180 but is not limited to pytest-asyncio. It adds support for using `freeze_time` as a decorator on coroutines (`@asyncio.coroutine` or `async def`). 