### PR TITLE
Ignore nose plugins to prevent test timing issues

### DIFF
--- a/freezegun/api.py
+++ b/freezegun/api.py
@@ -616,6 +616,7 @@ def freeze_time(time_to_freeze=None, tz_offset=0, ignore=None, tick=False, as_ar
 
     if ignore is None:
         ignore = []
+    ignore.append('nose.plugins')
     ignore.append('six.moves')
     ignore.append('django.utils.six.moves')
     ignore.append('google.gax')


### PR DESCRIPTION
When I upgraded from `freezegun` 0.3.9 to 0.3.10, my CircleCI builds started taking longer.  Upon further inspection, the tests were being distributed very strangely across the available containers.  This was because the `xunit` output about how long each test took to run was _very_ wrong; one test that took a few ms to run was marked as taking 25494780 seconds.  After realizing that value was being consistently reported every time, I thought time might be stopped, and sure enough, downgrading fixed my builds (as did this proposed change).

I'm not sure what is different between 0.3.9 and 0.3.10 that breaks the timing component of the built-in `xunit` plugin, so I can't offer a more targeted fix.  Please consider this change to add `nose.plugins` to the ignore list.