### PR TITLE
Added support for clock() function of time.

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -14,3 +14,4 @@ Patches and Suggestions
 - `Adam Johnson <https://github.com/adamchainz>`_
 - `Alex Ehlke <https://github.com/aehlke>`_
 - `James Lu <github.com/CrazyPython>`_
+- `Dan Elkis <github.com/rinslow>`_

--- a/freezegun/api.py
+++ b/freezegun/api.py
@@ -176,6 +176,14 @@ class FakeClock(object):
         first_frozen_time = self.times_to_freeze[0]()
         last_frozen_time = self.times_to_freeze[-1]()
 
+        if platform.python_version().startswith("2.6"):
+            # In Python 2.6 total_seconds() is not a function of timedelta,
+            # So we have to use the suggested alternative.
+            timedelta = (last_frozen_time - first_frozen_time)
+            return (timedelta.microseconds + 0.0 +
+                    (timedelta.seconds + timedelta.days * 24 * 3600)
+                    * 10 ** 6) / 10 ** 6
+
         return (last_frozen_time - first_frozen_time).total_seconds()
 
 

--- a/freezegun/api.py
+++ b/freezegun/api.py
@@ -176,15 +176,13 @@ class FakeClock(object):
         first_frozen_time = self.times_to_freeze[0]()
         last_frozen_time = self.times_to_freeze[-1]()
 
-        if platform.python_version().startswith("2.6"):
-            # In Python 2.6 total_seconds() is not a function of timedelta,
-            # So we have to use the suggested alternative.
-            timedelta = (last_frozen_time - first_frozen_time)
-            return (timedelta.microseconds + 0.0 +
-                    (timedelta.seconds + timedelta.days * 24 * 3600)
-                    * 10 ** 6) / 10 ** 6
+        # We can't use total_seconds() as it is not a function of timedelta
+        # in Python 2.6, so we have to use the suggested alternative.
+        timedelta = (last_frozen_time - first_frozen_time)
+        return (timedelta.microseconds + 0.0 +
+                (timedelta.seconds + timedelta.days * 24 * 3600)
+                * 10 ** 6) / 10 ** 6
 
-        return (last_frozen_time - first_frozen_time).total_seconds()
 
 
 class FakeDateMeta(type):

--- a/freezegun/api.py
+++ b/freezegun/api.py
@@ -19,6 +19,7 @@ real_time = time.time
 real_localtime = time.localtime
 real_gmtime = time.gmtime
 real_strftime = time.strftime
+real_clock = time.clock
 real_date = datetime.date
 real_datetime = datetime.datetime
 real_date_objects = [real_time, real_localtime, real_gmtime, real_strftime, real_date, real_datetime]
@@ -160,6 +161,22 @@ class FakeStrfTime(object):
         if time_to_format is None:
             time_to_format = FakeLocalTime(self.time_to_freeze)()
         return real_strftime(format, time_to_format)
+
+
+class FakeClock(object):
+    times_to_freeze = []
+
+    def __init__(self, previous_clock_function):
+        self.previous_clock_function = previous_clock_function
+
+    def __call__(self, *args, **kwargs):
+        if len(self.times_to_freeze) == 1:
+            return 0.0
+
+        first_frozen_time = self.times_to_freeze[0]()
+        last_frozen_time = self.times_to_freeze[-1]()
+
+        return (last_frozen_time - first_frozen_time).total_seconds()
 
 
 class FakeDateMeta(type):
@@ -472,10 +489,13 @@ class _freeze_time(object):
         fake_localtime = FakeLocalTime(time_to_freeze, time.localtime)
         fake_gmtime = FakeGMTTime(time_to_freeze, time.gmtime)
         fake_strftime = FakeStrfTime(time_to_freeze, time.strftime)
+        fake_clock = FakeClock(time.clock)
+        fake_clock.times_to_freeze.append(time_to_freeze)
         time.time = fake_time
         time.localtime = fake_localtime
         time.gmtime = fake_gmtime
         time.strftime = fake_strftime
+        time.clock = fake_clock
         if uuid_generate_time_attr:
             setattr(uuid, uuid_generate_time_attr, None)
         uuid._UuidCreate = None
@@ -492,6 +512,7 @@ class _freeze_time(object):
             ('real_localtime', real_localtime, 'FakeLocalTime', fake_localtime),
             ('real_strftime', real_strftime, 'FakeStrfTime', fake_strftime),
             ('real_time', real_time, 'FakeTime', fake_time),
+            ('real_clock', real_clock, 'FakeClock', fake_clock),
         ]
         self.fake_names = tuple(fake_name for real_name, real, fake_name, fake in to_patch)
         self.reals = dict((id(fake), real) for real_name, real, fake_name, fake in to_patch)
@@ -526,6 +547,7 @@ class _freeze_time(object):
         datetime.datetime.tz_offsets.pop()
         datetime.date.dates_to_freeze.pop()
         datetime.date.tz_offsets.pop()
+        time.clock.times_to_freeze.pop()
 
         if not datetime.datetime.times_to_freeze:
             datetime.datetime = real_datetime
@@ -567,6 +589,7 @@ class _freeze_time(object):
         time.gmtime = time.gmtime.previous_gmtime_function
         time.localtime = time.localtime.previous_localtime_function
         time.strftime = time.strftime.previous_strftime_function
+        time.clock = time.clock.previous_clock_function
 
         if uuid_generate_time_attr:
             setattr(uuid, uuid_generate_time_attr, real_uuid_generate_time)

--- a/tests/test_datetimes.py
+++ b/tests/test_datetimes.py
@@ -201,6 +201,17 @@ def test_time_gmtime():
         assert time_struct.tm_isdst == -1
 
 
+def test_time_clock():
+    with freeze_time('2012-01-14 03:21:34'):
+        assert time.clock() == 0
+
+        with freeze_time('2012-01-14 03:21:35'):
+            assert time.clock() == 1
+
+        with freeze_time('2012-01-14 03:21:36'):
+            assert time.clock() == 2
+
+
 class modify_timezone(object):
 
     def __init__(self, new_timezone):

--- a/tests/test_ticking.py
+++ b/tests/test_ticking.py
@@ -14,6 +14,40 @@ def test_ticking_datetime():
 
 
 @utils.cpython_only
+def test_ticking_time_clock():
+    with freeze_time('2012-01-14 03:21:34', tick=True):
+        first = time.clock()
+        time.sleep(0.001)  # Deal with potential clock resolution problems
+        with freeze_time('2012-01-14 03:21:35', tick=True):
+            second = time.clock()
+            time.sleep(0.001)  # Deal with potential clock resolution problems
+
+        with freeze_time('2012-01-14 03:21:36', tick=True):
+            third = time.clock()
+            time.sleep(0.001)
+
+        # Rewind time backwards
+        with freeze_time('2012-01-14 03:20:00', tick=True):
+            fourth = time.clock()
+            time.sleep(0.001)
+            fifth = time.clock()
+
+        assert first > 0
+        assert second > first
+        assert second > first + 1
+        assert second > 1
+        assert third > second
+        assert third > second + 1
+        assert third > 2
+
+        assert third > fourth
+        assert second > fourth
+        assert first > fourth
+
+        assert fifth > fourth
+
+
+@utils.cpython_only
 def test_ticking_date():
     with freeze_time("Jan 14th, 2012, 23:59:59.9999999", tick=True):
         time.sleep(0.001)  # Deal with potential clock resolution problems


### PR DESCRIPTION
So basically this was done as requested in https://github.com/spulec/freezegun/issues/228

The author did not specify the desired functionality so I had to suggest my own, 
It's pretty clear from the unit-test

```python
def test_time_clock():
    with freeze_time('2012-01-14 03:21:34'):
        assert time.clock() == 0

        with freeze_time('2012-01-14 03:21:35'):
            assert time.clock() == 1

        with freeze_time('2012-01-14 03:21:36'):
            assert time.clock() == 2
```

once inside a freeze you can reset the CPU time given to the process with additional freezes.
Looking forward for your feedback :) 
