### PR TITLE
Added tests_require to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ import sys
 from setuptools import setup
 
 requires = ['six']
+tests_require = ['mock', 'nose']
 
 if sys.version_info[0] == 2:
     requires += ['python-dateutil>=1.0, != 2.0']
@@ -24,6 +25,7 @@ setup(
     url='https://github.com/spulec/freezegun',
     packages=['freezegun'],
     install_requires=requires,
+    tests_require=tests_require,
     include_package_data=True,
     license='Apache 2.0',
     classifiers=[


### PR DESCRIPTION
This PR adds the `tests_require` keyword to `setup()` in `setup.py`, which declares the testing dependencies to allow running `python setup.py test` in an empty environment.