### PR TITLE
Drop support for EOL Python 2.6 and 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
   - pypy
   - 3.3
   - 3.4
+  - 3.5
   - 3.6
   - pypy3.3-5.2-alpha1
   - 3.7-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
   - 3.4
   - 3.5
   - 3.6
-  - pypy3.3-5.2-alpha1
+  - pypy3
   - 3.7-dev
 script: make travis
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 language: python
 python:
-  - 2.6
   - 2.7
   - pypy
-  - 3.3
   - 3.4
   - 3.5
   - 3.6

--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ FreezeGun: Let your Python tests travel through time
 .. image:: https://coveralls.io/repos/spulec/freezegun/badge.svg?branch=master
    :target: https://coveralls.io/r/spulec/freezegun
 
-FreezeGun is a library that allows your python tests to travel through time by mocking the datetime module.
+FreezeGun is a library that allows your Python tests to travel through time by mocking the datetime module.
 
 Usage
 -----
@@ -42,7 +42,7 @@ Decorator
         def test_the_class(self):
             assert datetime.datetime.now() == datetime.datetime(2012, 1, 14)
 
-Context Manager
+Context manager
 ~~~~~~~~~~~~~~~
 
 .. code-block:: python
@@ -135,7 +135,7 @@ parameters which will keep time stopped.
 Manual ticks
 ~~~~~~~~~~~~
 
-Freezegun allows for the time to be manually forwarded as well.
+FreezeGun allows for the time to be manually forwarded as well.
 
 .. code-block:: python
 
@@ -156,7 +156,7 @@ Freezegun allows for the time to be manually forwarded as well.
 Moving time to specify datetime
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Freezegun allows moving time to specific dates.
+FreezeGun allows moving time to specific dates.
 
 .. code-block:: python
 
@@ -185,10 +185,10 @@ Freezegun allows moving time to specific dates.
 Parameter for ``move_to`` can be any valid ``freeze_time`` date (string, date, datetime).
 
 
-Default Arguments
+Default arguments
 ~~~~~~~~~~~~~~~~~
 
-Note that Freezegun will not modify default arguments. The following code will
+Note that FreezeGun will not modify default arguments. The following code will
 print the current date. See `here <http://docs.python-guide.org/en/latest/writing/gotchas/#mutable-default-arguments>`_ for why.
 
 .. code-block:: python

--- a/freezegun/api.py
+++ b/freezegun/api.py
@@ -184,12 +184,8 @@ class FakeClock(object):
         first_frozen_time = self.times_to_freeze[0]()
         last_frozen_time = self.times_to_freeze[-1]()
 
-        # We can't use total_seconds() as it is not a function of timedelta
-        # in Python 2.6, so we have to use the suggested alternative.
         timedelta = (last_frozen_time - first_frozen_time)
-        total_seconds = (timedelta.microseconds + 0.0 +
-                         (timedelta.seconds + timedelta.days * 24 * 3600)
-                         * 10 ** 6) / 10 ** 6
+        total_seconds = timedelta.total_seconds()
 
         if self.tick:
             total_seconds += self.previous_clock_function()

--- a/setup.py
+++ b/setup.py
@@ -40,5 +40,6 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup
 requires = ['six']
 tests_require = ['mock', 'nose']
 
-if sys.version_info[0] == 2:
+if sys.version_info.major == 2:
     requires += ['python-dateutil>=1.0, != 2.0']
 else:
     # Py3k
@@ -29,14 +29,12 @@ setup(
     tests_require=tests_require,
     include_package_data=True,
     license='Apache 2.0',
-    python_requires='>=2.6, !=3.0.*, !=3.1.*, !=3.2.*',
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
     classifiers=[
         'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
     tests_require=tests_require,
     include_package_data=True,
     license='Apache 2.0',
+    python_requires='>=2.6, !=3.0.*, !=3.1.*, !=3.2.*',
     classifiers=[
         'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python :: 2',

--- a/setup.py
+++ b/setup.py
@@ -41,5 +41,7 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: Implementation :: CPython',
+        'Programming Language :: Python :: Implementation :: PyPy',
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py26, py27, pypy, py33, py34, py35, py36, py37, pypy3
+envlist = py27, pypy, py34, py35, py36, py37, pypy3
 
 [testenv]
 commands = make test NOSE_ARGS="{posargs}"

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py26, py27, pypy, py32, py33, py34, pypy3
+envlist = py26, py27, pypy, py33, py34, py35, py36, py37, pypy3
 
 [testenv]
 commands = make test NOSE_ARGS="{posargs}"


### PR DESCRIPTION
Python 2.6 and 3.3 are EOL and no longer receiving security updates (or any updates) from the core Python team.

They're also little used.

Here's the pip installs for FreezeGun from PyPI for May 2018:

| python_version | percent | download_count |
| -------------- | ------: | -------------: |
| 2.7            |  54.99% |         69,976 |
| 3.6            |  30.07% |         38,257 |
| 3.5            |  10.59% |         13,479 |
| 3.4            |   3.68% |          4,679 |
| 2.6            |   0.48% |            616 |
| 3.7            |   0.10% |            126 |
| 3.3            |   0.09% |            110 |
| Total          |         |        127,243 |

Source: `pypinfo --start-date 2018-05-01 --end-date 2018-05-31 --percent --markdown freezegun pyversion`

---

Includes https://github.com/spulec/freezegun/pull/247 to avoid merge conflicts, and the last commit is unique to this PR.
