### PR TITLE
Fix typo in long_description

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     name='freezegun',
     version='0.3.10',
     description='Let your Python tests travel through time',
-    long_desciption=readme,
+    long_description=readme,
     author='Steve Pulec',
     author_email='spulec@gmail.com',
     url='https://github.com/spulec/freezegun',


### PR DESCRIPTION
There's no description on PyPI:

![image](https://user-images.githubusercontent.com/1324225/40999078-7bfc24f8-6912-11e8-9683-29a0562caef8.png)

https://pypi.org/project/freezegun/#description

And only because of a little typo in setup.py!