### PR TITLE
Feature: Lazy Ticking

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -132,6 +132,57 @@ parameters which will keep time stopped.
     def test_nice_datetime():
         assert datetime.datetime.now() > datetime.datetime(2020, 1, 14)
 
+``lazy_tick`` argument
+~~~~~~~~~~~~~~~~~
+
+FreezeGun's ``lazy_tick`` allows time to only tick when the time functions are called.
+
+If ``lazy_tick`` is ``True``, then each tick will jump time forward 1 second.
+
+.. code-block:: python
+
+    @freeze_time("Jan 14th, 2020", lazy_tick=True)
+    def test_lazy_ticking():
+        assert datetime.datetime.now() == datetime.datetime(2020, 1, 14)
+        time.sleep(10)
+        # Even though 10 seconds have elapsed, datetime.datetime.now() will
+        # indicate that only 1 second has passed
+        assert datetime.datetime.now() == datetime.datetime(2020, 1, 14, 0, 0, 1)
+
+If ``lazy_tick`` is an iterable/generator of datetimes, then each tick will jump
+to the next datetime in the sequence.
+
+.. code-block:: python
+
+    dates = [
+        '1020-01-14',
+        'Jan 14th, 2020',
+        'January 1, 3020',
+    ]
+    @freeze_time("Jan 14th, 2020", lazy_tick=dates)
+    def test_list_of_datetimes():
+        assert datetime.datetime.now() == datetime.datetime(2020, 1, 14)
+        assert datetime.datetime.now() == datetime.datetime(1020, 1, 14)
+        assert datetime.datetime.now() == datetime.datetime(3020, 1, 1)
+
+        try:
+            # If no more times are available in the sequence,
+            # a StopIteration exception is raised
+            datetime.datetime.now()
+        except StopIteration:
+            pass
+
+Finally if ``lazy_tick`` is a dateime.timedelta instance, then each tick will jump
+forward by the specified amount of time.
+
+.. code-block:: python
+
+    @freeze_time("Jan 14th, 2020", lazy_tick=datetime.timedelta(months=1))
+    def test_nice_datetime():
+        assert datetime.datetime.now() == datetime.datetime(2020, 1, 14)
+        assert datetime.datetime.now() == datetime.datetime(2020, 2, 14)
+        assert datetime.datetime.now() == datetime.datetime(2020, 3, 14)
+
 Manual ticks
 ~~~~~~~~~~~~
 

--- a/tests/test_lazy_ticking.py
+++ b/tests/test_lazy_ticking.py
@@ -1,0 +1,98 @@
+import datetime
+import time
+import mock
+
+from freezegun import freeze_time
+from nose.tools import assert_raises
+from tests import utils
+
+ONE_SECOND = datetime.timedelta(seconds=1)
+ONE_HOUR = datetime.timedelta(hours=1)
+ONE_DAY = datetime.timedelta(days=1)
+
+Y2K = datetime.datetime(year=2000, month=1, day=1)
+
+
+@utils.cpython_only
+def test_infinite_lazy_ticking_with_timedelta():
+    with freeze_time("Jan 14th, 2012", lazy_tick=ONE_HOUR):
+        assert datetime.datetime.now() == datetime.datetime(2012, 1, 14)
+        assert datetime.datetime.now() - datetime.datetime(2012, 1, 14) == ONE_HOUR
+
+
+@utils.cpython_only
+def test_infinite_lazy_ticking_with_true():
+    with freeze_time("Jan 14th, 2012", lazy_tick=True):
+        assert datetime.datetime.now() == datetime.datetime(2012, 1, 14)
+        assert datetime.datetime.now() - datetime.datetime(2012, 1, 14) == ONE_SECOND
+
+
+def _next_datetimes_generator():
+    for i in range(1, 4):
+        yield Y2K + ONE_HOUR * i
+
+
+def _test_finite_lazy_ticking(lazy_tick):
+    with freeze_time(Y2K, lazy_tick=lazy_tick):
+        for i in range(0, 4):
+            datetime.datetime.now() == Y2K + ONE_HOUR * i
+
+        assert_raises(StopIteration, datetime.datetime.now)
+
+
+@utils.cpython_only
+def test_finite_lazy_ticking_with_generator():
+    _test_finite_lazy_ticking(_next_datetimes_generator())
+
+
+@utils.cpython_only
+def test_finite_lazy_ticking_with_iterable():
+    next_datetimes_list = list(_next_datetimes_generator())
+    _test_finite_lazy_ticking(next_datetimes_list)
+
+
+@utils.cpython_only
+def test_infinite_ticking_time_clock():
+    with freeze_time('2012-01-14 03:21:34'):
+        reference = time.clock()
+        # Move forwards in time
+        with freeze_time('2012-01-14 03:21:35', lazy_tick=ONE_HOUR):
+            assert time.clock() - reference == 1
+            assert time.clock() - reference == ONE_HOUR.total_seconds() + 1
+
+        # Move backwards in time
+        with freeze_time('2012-01-14 03:21:32', lazy_tick=-ONE_DAY):
+            assert time.clock() - reference == - 2
+            assert time.clock() - reference == - ONE_DAY.total_seconds() - 2
+
+
+@utils.cpython_only
+def test_ticking_date():
+    with freeze_time("Jan 14th, 2012, 23:59:59.9999999", lazy_tick=True):
+        assert datetime.date.today() == datetime.date(2012, 1, 14)
+        assert datetime.date.today() == datetime.date(2012, 1, 15)
+
+
+@utils.cpython_only
+def test_ticking_time():
+    with freeze_time("Jan 14th, 2012, 23:59:59", lazy_tick=True):
+        assert time.time() == 1326585599.0
+        assert time.time() == 1326585600.0
+
+
+@mock.patch('freezegun.api._is_cpython', False)
+def test_pypy_compat():
+    try:
+        freeze_time("Jan 14th, 2012, 23:59:59", lazy_tick=True)
+    except SystemError:
+        pass
+    else:
+        raise AssertionError("lazy_tick=True should error on non-CPython")
+
+
+@mock.patch('freezegun.api._is_cpython', True)
+def test_non_pypy_compat():
+    try:
+        freeze_time("Jan 14th, 2012, 23:59:59", lazy_tick=True)
+    except Exception:
+        raise AssertionError("lazy_tick=True should not error on CPython")


### PR DESCRIPTION
# Problem
There are times when I'm using the tick argument of freeze_time and I feel that I need a finer level of control over the passage of time. This usually occurs when I'm working with a function, method, context manager, etc. that will hang and only resume execution until some specific point in time. e.g.

```python
with freeze_time('2020-01-01 12:00:00PM', tick=True):
    resume_in_10_minutes()
```

In this case, I don't have an elegant way to handle the passage of time; if I try to move time forward with `.move_to` before calling the function, then the context of the function changes.

# Solution

In this PR I propose adding a lazy_tick argument to freeze_time that lets you control when exactly time is ticking, how fast it's ticking, and can also let you know if more time has elapsed then you expected by raising an exception.

I'll use the above example to demonstrate it's use:

```python
datetimes = [
    '2020-01-01 12:05:00PM',
    '2020-01-01 12:10:00PM'
    '2020-01-01 12:15:00PM'
]
with freeze_time('2020-01-01 12:00:00PM', lazy_tick=datetimes):
    resume_in_10_minutes()
    assert datetime.datetime.now() == datetime.datetime(2020, 1, 14, 12, 15, 0)
```

# Full Spec
### The ```lazy_tick``` argument

`lazy_tick` allows time to only tick when the time functions are called.

If `lazy_tick` is `True`, then each tick will jump time forward 1 second.

```python
@freeze_time("Jan 14th, 2020", lazy_tick=True)
def test_lazy_ticking():
    assert datetime.datetime.now() == datetime.datetime(2020, 1, 14)
    time.sleep(10)
    # Even though 10 seconds have elapsed, datetime.datetime.now() will
    # indicate that only 1 second has passed
    assert datetime.datetime.now() == datetime.datetime(2020, 1, 14, 0, 0, 1)
```

If `lazy_tick` is an iterable/generator of datetimes, then each tick will jump
to the next datetime in the sequence.

```python
dates = [
    '1020-01-14',
    'Jan 14th, 2020',
    'January 1, 3020',
]
@freeze_time("Jan 14th, 2020", lazy_tick=dates)
def test_list_of_datetimes():
    assert datetime.datetime.now() == datetime.datetime(2020, 1, 14)
    assert datetime.datetime.now() == datetime.datetime(1020, 1, 14)
    assert datetime.datetime.now() == datetime.datetime(3020, 1, 1)

    try:
        # If no more times are available in the sequence,
        # a StopIteration exception is raised
        datetime.datetime.now()
    except StopIteration:
        pass
```

Finally if `lazy_tick` is a dateime.timedelta instance, then each tick will jump
forward by the specified amount of time.

```python
@freeze_time("Jan 14th, 2020", lazy_tick=datetime.timedelta(months=1))
def test_nice_datetime():
    assert datetime.datetime.now() == datetime.datetime(2020, 1, 14)
    assert datetime.datetime.now() == datetime.datetime(2020, 2, 14)
    assert datetime.datetime.now() == datetime.datetime(2020, 3, 14)
```