### PR TITLE
cut a release for 0.3.12

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,11 @@ Freezegun Changelog
 Latest
 ------
 
+0.3.12
+------
+
+* Feature: added `auto_tick_seconds` param to freezetime (PR #201)
+
 0.3.11
 ------
 

--- a/freezegun/__init__.py
+++ b/freezegun/__init__.py
@@ -9,7 +9,7 @@ freezegun
 from .api import freeze_time
 
 __title__ = 'freezegun'
-__version__ = '0.3.11'
+__version__ = '0.3.12'
 __author__ = 'Steve Pulec'
 __license__ = 'Apache License 2.0'
 __copyright__ = 'Copyright 2012 Steve Pulec'

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ with open('README.rst') as f:
 
 setup(
     name='freezegun',
-    version='0.3.11',
+    version='0.3.12',
     description='Let your Python tests travel through time',
     long_description=readme,
     author='Steve Pulec',


### PR DESCRIPTION
The `auto_tick_seconds` has been a handy feature and it would be great to get this deployed to pypi.