### PR TITLE
Ignore _pytest.runner by default

### DIFF
--- a/freezegun/api.py
+++ b/freezegun/api.py
@@ -727,6 +727,7 @@ def freeze_time(time_to_freeze=None, tz_offset=0, ignore=None, tick=False, as_ar
     ignore.append('selenium')
     ignore.append('_pytest.terminal.')
     ignore.append('_pytest.runner.')
+    ignore.append('_pytest.runner')
     
     return _freeze_time(time_to_freeze, tz_offset, ignore, tick, as_arg, auto_tick_seconds)
 

--- a/tests/test_datetimes.py
+++ b/tests/test_datetimes.py
@@ -8,7 +8,7 @@ from unittest import SkipTest
 import pytest
 from tests import utils
 
-from freezegun import freeze_time
+from freezegun import api, freeze_time
 from freezegun.api import FakeDatetime, FakeDate
 
 try:
@@ -628,6 +628,16 @@ def test_time_with_nested():
         assert time() == second
 
 
+@pytest.fixture
+def change_stack_limit():
+    ori_val = api.call_stack_inspection_limit
+    api.call_stack_inspection_limit = 100  # just to increase coverage
+    yield
+    # Restore to normal after test(s)
+    api.call_stack_inspection_limit = ori_val
+
+
+@pytest.mark.usefixtures('change_stack_limit')
 def test_should_use_real_time():
     frozen = datetime.datetime(2015, 3, 5)
     expected_frozen = 1425513600.0
@@ -635,9 +645,6 @@ def test_should_use_real_time():
     # expected_frozen_local = (2015, 3, 5, 1, 0, 0, 3, 64, -1)
     expected_frozen_gmt = (2015, 3, 5, 0, 0, 0, 3, 64, -1)
     expected_clock = 0
-
-    from freezegun import api
-    api.call_stack_inspection_limit = 100  # just to increase coverage
 
     with freeze_time(frozen):
         assert time.time() == expected_frozen


### PR DESCRIPTION
This will fix pytest duration calculation. Fixes #286