### PR TITLE
Conditionally patch time.clock

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,12 @@ matrix:
     - python: 3.7
       dist: xenial
       sudo: required
+    - python: 3.8-dev
+      dist: xenial
+      sudo: required
+  allow_failures:
+    - python: "3.8-dev"
+
 script: make travis
 install:
   - pip install .

--- a/freezegun/api.py
+++ b/freezegun/api.py
@@ -25,11 +25,13 @@ real_time = time.time
 real_localtime = time.localtime
 real_gmtime = time.gmtime
 real_strftime = time.strftime
-real_clock = time.clock
 real_date = datetime.date
 real_datetime = datetime.datetime
 real_date_objects = [real_time, real_localtime, real_gmtime, real_strftime, real_date, real_datetime]
 _real_time_object_ids = set(id(obj) for obj in real_date_objects)
+
+# time.clock is deprecated and was removed in Python 3.8
+real_clock = getattr(time, 'clock', None)
 
 freeze_factories = []
 tz_offsets = []
@@ -201,24 +203,24 @@ def fake_strftime(format, time_to_format=None):
     else:
         return real_strftime(format, time_to_format)
 
+if real_clock is not None:
+    def fake_clock():
+        if _should_use_real_time():
+            return real_clock()
 
-def fake_clock():
-    if _should_use_real_time():
-        return real_clock()
+        if len(freeze_factories) == 1:
+            return 0.0 if not tick_flags[-1] else real_clock()
 
-    if len(freeze_factories) == 1:
-        return 0.0 if not tick_flags[-1] else real_clock()
+        first_frozen_time = freeze_factories[0]()
+        last_frozen_time = get_current_time()
 
-    first_frozen_time = freeze_factories[0]()
-    last_frozen_time = get_current_time()
+        timedelta = (last_frozen_time - first_frozen_time)
+        total_seconds = timedelta.total_seconds()
 
-    timedelta = (last_frozen_time - first_frozen_time)
-    total_seconds = timedelta.total_seconds()
+        if tick_flags[-1]:
+            total_seconds += real_clock()
 
-    if tick_flags[-1]:
-        total_seconds += real_clock()
-
-    return total_seconds
+        return total_seconds
 
 
 class FakeDateMeta(type):
@@ -579,7 +581,6 @@ class _freeze_time(object):
         time.localtime = fake_localtime
         time.gmtime = fake_gmtime
         time.strftime = fake_strftime
-        time.clock = fake_clock
         if uuid_generate_time_attr:
             setattr(uuid, uuid_generate_time_attr, None)
         uuid._UuidCreate = None
@@ -596,8 +597,13 @@ class _freeze_time(object):
             ('real_localtime', real_localtime, fake_localtime),
             ('real_strftime', real_strftime, fake_strftime),
             ('real_time', real_time, fake_time),
-            ('real_clock', real_clock, fake_clock),
         ]
+
+        if real_clock is not None:
+            # time.clock is deprecated and was removed in Python 3.8
+            time.clock = fake_clock
+            to_patch.append(('real_clock', real_clock, fake_clock))
+
         self.fake_names = tuple(fake.__name__ for real_name, real, fake in to_patch)
         self.reals = dict((id(fake), real) for real_name, real, fake in to_patch)
         fakes = dict((id(real), fake) for real_name, real, fake in to_patch)

--- a/tests/test_datetimes.py
+++ b/tests/test_datetimes.py
@@ -17,6 +17,8 @@ try:
 except ImportError:
     maya = None
 
+# time.clock was removed in Python 3.8
+HAS_CLOCK = hasattr(time, 'clock')
 
 class temp_locale(object):
     """Temporarily change the locale."""
@@ -207,6 +209,8 @@ def test_time_gmtime():
         assert time_struct.tm_isdst == -1
 
 
+@pytest.mark.skipif(not HAS_CLOCK,
+                    reason="time.clock was removed in Python 3.8")
 def test_time_clock():
     with freeze_time('2012-01-14 03:21:34'):
         assert time.clock() == 0
@@ -643,10 +647,12 @@ def test_should_use_real_time():
         assert time.time() == expected_frozen
         # assert time.localtime() == expected_frozen_local
         assert time.gmtime() == expected_frozen_gmt
-        assert time.clock() == expected_clock
+        if HAS_CLOCK:
+            assert time.clock() == expected_clock
 
     with freeze_time(frozen, ignore=['_pytest', 'nose']):
         assert time.time() != expected_frozen
         # assert time.localtime() != expected_frozen_local
         assert time.gmtime() != expected_frozen_gmt
-        assert time.clock() != expected_clock
+        if HAS_CLOCK:
+            assert time.clock() != expected_clock

--- a/tests/test_ticking.py
+++ b/tests/test_ticking.py
@@ -1,10 +1,10 @@
 import datetime
 import time
 import mock
+import pytest
 
 from freezegun import freeze_time
 from tests import utils
-
 
 @utils.cpython_only
 def test_ticking_datetime():
@@ -13,6 +13,8 @@ def test_ticking_datetime():
         assert datetime.datetime.now() > datetime.datetime(2012, 1, 14)
 
 
+@pytest.mark.skipif(not hasattr(time, "clock"),
+                    reason="time.clock was removed in Python 3.8")
 @utils.cpython_only
 def test_ticking_time_clock():
     with freeze_time('2012-01-14 03:21:34', tick=True):


### PR DESCRIPTION
`time.clock` was removed in Python 3.8, which is causing `freezegun` to fail when importing the API module as it tries to stash and patch the clock function. This makes the patching logic conditional on the existence of a `time.clock` function.

`time.clock` has been deprecated for some time, and I guess it was just missed in at least my test suite because the *real* function was never invoked.

It may be worth hard failing on deprecation warnings in your test suite in the future, to avoid problems like this.