### PR TITLE
Remove setup.py from "publish" target

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-include README.rst LICENSE AUTHORS.rst CHANGELOG
+include README.rst LICENSE AUTHORS.rst CHANGELOG pyproject.toml
 recursive-include tests *
 global-exclude __pycache__
 global-exclude *.py[co]

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,9 @@ tdaemon:
 	tdaemon -t nose ./tests/ --custom-args="--with-growl"
 
 publish:
-	python setup.py sdist bdist_wheel upload
+	rm -rf dist
+	python setup.py sdist bdist_wheel
+	twine upload dist/*
 
 venv:
 	virtualenv venv

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ tdaemon:
 
 publish:
 	rm -rf dist
-	python setup.py sdist bdist_wheel
+	python -m pep517.build --source --binary .
 	twine upload dist/*
 
 venv:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
This replaces `setup.py upload` (which is deprecated and has caused problems for this library before) with `twine upload`, which is the modern way to do it.

I have also gone ahead and set up PEP 517/518 for this project, and used `pep517.build` to build the source and binary distributions, thus removing the need to invoke `setup.py` at all.

This both adds `pyproject.toml` and switches from `setup.py` to `twine`, but if you just want the `twine` command part of it, [the first commit](https://github.com/spulec/freezegun/pull/297/commits/8ccb2a4a8a20ac777e37a975eececb82aafd516b) doesn't include the `pyproject.toml` changes.