### PR TITLE
Update install instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -229,7 +229,7 @@ To install FreezeGun, simply:
 
     $ pip install freezegun
 
-On Debian (Testing and Unstable) systems:
+On Debian systems:
 
 .. code-block:: bash
 


### PR DESCRIPTION
Freezegun seems to be in Debian Stretch (stable) nowadays: https://packages.debian.org/stretch/python-freezegun