### PR TITLE
Use built mock from unittest when available (Python 3.4+)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,10 @@ import sys
 from setuptools import setup
 
 requires = ['six']
-tests_require = ['mock', 'nose']
+tests_require = [
+    'mock;python_version<"3.4"',
+    'nose'
+]
 
 if sys.version_info.major == 2:
     requires += ['python-dateutil>=1.0, != 2.0']

--- a/tests/test_ticking.py
+++ b/tests/test_ticking.py
@@ -1,6 +1,9 @@
 import datetime
 import time
-import mock
+try:
+    from unittest import mock
+except (ImportError, AttributeError):
+    import mock
 import pytest
 
 from freezegun import freeze_time

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,9 @@
 from unittest import SkipTest
 
-import mock
+try:
+    from unittest import mock
+except (ImportError, AttributeError):
+    import mock
 
 from freezegun import api
 from tests import utils


### PR DESCRIPTION
Use the mock built into unittest for Python 3.4+ rather than external mock