### PR TITLE
Use async def for python > 3.5

### DIFF
--- a/freezegun/_async_coroutine.py
+++ b/freezegun/_async_coroutine.py
@@ -5,12 +5,13 @@ import asyncio
 
 def wrap_coroutine(api, coroutine):
     @functools.wraps(coroutine)
-    async def wrapper(*args, **kwargs):
+    @asyncio.coroutine
+    def wrapper(*args, **kwargs):
         with api as time_factory:
             if api.as_arg:
-                result = await coroutine(time_factory, *args, **kwargs)
+                result = yield from coroutine(time_factory, *args, **kwargs)
             else:
-                result = await coroutine(*args, **kwargs)
+                result = yield from coroutine(*args, **kwargs)
         return result
 
     return wrapper

--- a/freezegun/api.py
+++ b/freezegun/api.py
@@ -79,7 +79,10 @@ except ImportError:
 
 try:
     iscoroutinefunction = inspect.iscoroutinefunction
-    from freezegun._async import wrap_coroutine
+    if sys.version_info < (3, 5):
+        from freezegun._async_coroutine import wrap_coroutine
+    else:
+        from freezegun._async import wrap_coroutine
 except AttributeError:
     iscoroutinefunction = lambda x: False
 


### PR DESCRIPTION
Took a stab at fixing #303. Modified `_async.py` to make use of `async def` keywords and moved the old `@asyncio.coroutine` style into a new `_async_coroutine.py` file. Conditionally import `_async_coroutine.py` only on python < 3.5. I purposely left the usage of `@asyncio.coroutine` in [test_asyncio.py](https://github.com/spulec/freezegun/blob/011138dc548bcf77c237a9f4f334b2838aa9d10b/tests/test_asyncio.py#L17) as the tests will fail due to syntax errors when run against older versions of python. This should fix the current issue when running under `python3.8 -Werror`.

@spulec  let me know if this looks like a decent direction or if I am missing something else around the original issue.