### PR TITLE
Make string_type private to fix generated type stubs

### DIFF
--- a/freezegun/api.py
+++ b/freezegun/api.py
@@ -48,9 +48,9 @@ tick_flags = []
 # Python3 doesn't have basestring, but it does have str.
 try:
     # noinspection PyUnresolvedReferences
-    string_type = basestring
+    _string_type = basestring
 except NameError:
-    string_type = str
+    _string_type = str
 
 try:
     # noinspection PyUnresolvedReferences
@@ -735,7 +735,7 @@ class _freeze_time(object):
 
 
 def freeze_time(time_to_freeze=None, tz_offset=0, ignore=None, tick=False, as_arg=False, auto_tick_seconds=0):
-    acceptable_times = (type(None), string_type, datetime.date, datetime.timedelta,
+    acceptable_times = (type(None), _string_type, datetime.date, datetime.timedelta,
              types.FunctionType, types.GeneratorType)
 
     if MayaDT is not None:


### PR DESCRIPTION
While generating type stubs for freezegun for usage with mypy I noticed that the output is broken. Instead of generating just one assignment of `string_type` it generates both, leading to errors in mypy when checking python 3 code since `basestring` doesn't exist.

I didn't find an easy way to fix this in mypy so I thought the simplest solution was to make the `string_type` in freezegun private since mypy's stubgen tool doesn't generate definitions for private names.

Stubgen output before:
```python
string_type = basestring
string_type = str
```

After: nothing, since the type alias is now private.