### PR TITLE
Add type annotations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 language: python
 cache: pip
 python:
-  - 2.7
-  - pypy
-  - 3.4
   - 3.5
   - 3.6
   - pypy3

--- a/freezegun/_async.py
+++ b/freezegun/_async.py
@@ -1,12 +1,18 @@
-import functools
-
 import asyncio
+import functools
+from typing import TYPE_CHECKING, Any, Callable, TypeVar, cast
+
+if TYPE_CHECKING:
+    from .api import _freeze_time
 
 
-def wrap_coroutine(api, coroutine):
+_CallableT = TypeVar("_CallableT", bound=Callable[..., Any])
+
+
+def wrap_coroutine(api: '_freeze_time', coroutine: _CallableT) -> _CallableT:
     @functools.wraps(coroutine)
     @asyncio.coroutine
-    def wrapper(*args, **kwargs):
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
         with api as time_factory:
             if api.as_arg:
                 result = yield from coroutine(time_factory, *args, **kwargs)
@@ -14,4 +20,4 @@ def wrap_coroutine(api, coroutine):
                 result = yield from coroutine(*args, **kwargs)
         return result
 
-    return wrapper
+    return cast(_CallableT, wrapper)

--- a/freezegun/api.py
+++ b/freezegun/api.py
@@ -19,6 +19,8 @@ from typing import (
 from dateutil import parser
 from dateutil.tz import tzlocal
 
+from freezegun._async import wrap_coroutine
+
 try:
     from maya import MayaDT as _MayaDT  # type: ignore
 except ImportError:
@@ -79,14 +81,7 @@ except (AttributeError, ImportError):
     real_uuid_create = None
 
 
-if sys.version_info >= (3, 5):
-    iscoroutinefunction = inspect.iscoroutinefunction
-    from freezegun._async import wrap_coroutine
-else:
-    iscoroutinefunction = lambda x: False
 
-    def wrap_coroutine(api: _freeze_time, coroutine: _CallableT) -> _CallableT:
-        raise NotImplementedError()
 
 
 # keep a cache of module attributes otherwise freezegun will need to analyze too many modules all the time
@@ -552,7 +547,7 @@ class _freeze_time(object):
     def __call__(self, func: _CallableOrTypeT) -> _CallableOrTypeT:
         if inspect.isclass(func):
             return cast(_CallableOrTypeT, self.decorate_class(cast(Any, func)))
-        elif iscoroutinefunction(func):
+        elif inspect.iscoroutinefunction(func):
             return self.decorate_coroutine(func)
         return self.decorate_callable(func)
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,12 @@
+[mypy]
+
+disallow_untyped_decorators = True
+disallow_subclassing_any = True
+disallow_untyped_calls = True
+disallow_untyped_defs = True
+no_implicit_optional = True
+check_untyped_defs = True
+warn_redundant_casts = True
+warn_return_any = True
+warn_unused_ignores = True
+strict_optional = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ pytest-coverage
 coveralls
 mock
 pytest==3.10.1
-maya; python_version == '2.7' or python_version >= '3.6'
+maya; python_version >= '3.6'

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,8 @@ setup(
     author_email='spulec@gmail.com',
     url='https://github.com/spulec/freezegun',
     packages=['freezegun'],
+    package_data={'freezegun':['py.typed']},
+    zip_safe=False,
     install_requires=requires,
     tests_require=tests_require,
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -3,18 +3,8 @@
 import sys
 from setuptools import setup
 
-requires = ['six']
-tests_require = [
-    'mock;python_version<"3.4"',
-    'nose'
-]
-
-if sys.version_info.major == 2:
-    requires += ['python-dateutil>=1.0, != 2.0']
-else:
-    # Py3k
-    requires += ['python-dateutil>=2.0']
-
+requires = ['six', 'python-dateutil>=2.0']
+tests_require = ['nose']
 
 with open('README.rst') as f:
     readme = f.read()
@@ -34,13 +24,10 @@ setup(
     tests_require=tests_require,
     include_package_data=True,
     license='Apache 2.0',
-    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
+    python_requires='>=3.5',
     classifiers=[
         'License :: OSI Approved :: Apache Software License',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, pypy, py34, py35, py36, py37, pypy3
+envlist = py35, py36, py37, pypy3
 
 [testenv]
 commands = make test NOSE_ARGS="{posargs}"


### PR DESCRIPTION
Concerns #318.

A first shot of adding type annotations to the library.
This is just for getting some feedback there might be some clean up work to do.

A few notes:
* As discussed in #318, this would drop support for any Python version below 3.5 to allow using type annotations instead of type comments. This also simplifies things like string types, `copyreg` and coroutine handling.
* Coroutine handling could be further simplified using only the `async def` variant seen in #316 (since that is supported since 3.5)
* Type comments (`# type: ...`) are used for variables and class fields since annotating these directly would require dropping support for Python 3.5 (EOL is 09/2020).
* There are quite a few `# type: ignore` comments that are (as far as I can tell) unavoidable because they deal with private fields from stdlib modules and assigning to types (which mypy doesn't allow)