### PR TITLE
Revert "Merge pull request #311"

### DIFF
--- a/freezegun/api.py
+++ b/freezegun/api.py
@@ -26,10 +26,9 @@ real_time = time.time
 real_localtime = time.localtime
 real_gmtime = time.gmtime
 real_strftime = time.strftime
-real_timegm = calendar.timegm
 real_date = datetime.date
 real_datetime = datetime.datetime
-real_date_objects = [real_time, real_localtime, real_gmtime, real_strftime, real_timegm, real_date, real_datetime]
+real_date_objects = [real_time, real_localtime, real_gmtime, real_strftime, real_date, real_datetime]
 
 if _TIME_NS_PRESENT:
     real_time_ns = time.time_ns
@@ -183,7 +182,7 @@ def fake_time():
     if _should_use_real_time():
         return real_time()
     current_time = get_current_time()
-    return real_timegm(current_time.timetuple()) + current_time.microsecond / 1000000.0
+    return calendar.timegm(current_time.timetuple()) + current_time.microsecond / 1000000.0
 
 if _TIME_NS_PRESENT:
     def fake_time_ns():
@@ -218,14 +217,6 @@ def fake_strftime(format, time_to_format=None):
         return real_strftime(format)
     else:
         return real_strftime(format, time_to_format)
-
-
-def fake_timegm(struct_time):
-    if _should_use_real_time():
-        return real_timegm(struct_time)
-    else:
-        return real_timegm(get_current_time().timetuple())
-
 
 if real_clock is not None:
     def fake_clock():
@@ -598,8 +589,6 @@ class _freeze_time(object):
             return freeze_factory
 
         # Change the modules
-        calendar.timegm = fake_timegm
-
         datetime.datetime = FakeDatetime
         datetime.date = FakeDate
 
@@ -623,7 +612,6 @@ class _freeze_time(object):
             ('real_localtime', real_localtime, fake_localtime),
             ('real_strftime', real_strftime, fake_strftime),
             ('real_time', real_time, fake_time),
-            ('real_timegm', real_timegm, fake_timegm),
         ]
 
         if _TIME_NS_PRESENT:
@@ -670,7 +658,6 @@ class _freeze_time(object):
         tz_offsets.pop()
 
         if not freeze_factories:
-            calendar.timegm = real_timegm
             datetime.datetime = real_datetime
             datetime.date = real_date
             copyreg.dispatch_table.pop(real_datetime)

--- a/tests/another_module.py
+++ b/tests/another_module.py
@@ -1,4 +1,3 @@
-from calendar import timegm
 from datetime import date, datetime
 from time import time, localtime, gmtime, strftime
 
@@ -9,7 +8,6 @@ from freezegun.api import (
     fake_localtime,
     fake_gmtime,
     fake_strftime,
-    fake_timegm,
 )
 
 
@@ -39,10 +37,6 @@ def get_strftime():
     return strftime
 
 
-def get_timegm():
-    return timegm
-
-
 # Fakes
 
 def get_fake_datetime():
@@ -67,7 +61,3 @@ def get_fake_gmtime():
 
 def get_fake_strftime():
     return fake_strftime
-
-
-def get_fake_timegm():
-    return fake_timegm

--- a/tests/test_class_import.py
+++ b/tests/test_class_import.py
@@ -1,5 +1,3 @@
-import calendar
-import datetime
 import time
 import sys
 from .fake_module import (
@@ -19,8 +17,8 @@ from freezegun.api import (
     fake_localtime,
     fake_gmtime,
     fake_strftime,
-    fake_timegm,
 )
+import datetime
 
 
 @freeze_time("2012-01-14")
@@ -150,8 +148,6 @@ def test_import_after_start():
         assert another_module.get_gmtime() is fake_gmtime
         assert another_module.get_strftime() is time.strftime
         assert another_module.get_strftime() is fake_strftime
-        assert another_module.get_timegm() is calendar.timegm
-        assert another_module.get_timegm() is fake_timegm
 
         # Fakes
         assert another_module.get_fake_datetime() is FakeDatetime
@@ -160,7 +156,6 @@ def test_import_after_start():
         assert another_module.get_fake_localtime() is fake_localtime
         assert another_module.get_fake_gmtime() is fake_gmtime
         assert another_module.get_fake_strftime() is fake_strftime
-        assert another_module.get_fake_timegm() is fake_timegm
 
     # Reals
     assert another_module.get_datetime() is datetime.datetime
@@ -175,8 +170,6 @@ def test_import_after_start():
     assert not another_module.get_gmtime() is fake_gmtime
     assert another_module.get_strftime() is time.strftime
     assert not another_module.get_strftime() is fake_strftime
-    assert another_module.get_timegm() is calendar.timegm
-    assert not another_module.get_timegm() is fake_timegm
 
     # Fakes
     assert another_module.get_fake_datetime() is FakeDatetime
@@ -185,7 +178,6 @@ def test_import_after_start():
     assert another_module.get_fake_localtime() is fake_localtime
     assert another_module.get_fake_gmtime() is fake_gmtime
     assert another_module.get_fake_strftime() is fake_strftime
-    assert another_module.get_fake_timegm() is fake_timegm
 
 
 def test_none_as_initial():

--- a/tests/test_datetimes.py
+++ b/tests/test_datetimes.py
@@ -1,4 +1,5 @@
 import time
+import calendar
 import datetime
 import unittest
 import locale
@@ -644,6 +645,9 @@ def test_should_use_real_time():
     from freezegun import api
     api.call_stack_inspection_limit = 100  # just to increase coverage
 
+    timestamp_to_convert = 1579602312
+    time_tuple = time.gmtime(timestamp_to_convert)
+
     with freeze_time(frozen):
         assert time.time() == expected_frozen
         # assert time.localtime() == expected_frozen_local
@@ -653,6 +657,9 @@ def test_should_use_real_time():
         if HAS_TIME_NS:
             assert time.time_ns() == expected_frozen * 1e9
 
+        assert calendar.timegm(time.gmtime()) == expected_frozen
+        assert calendar.timegm(time_tuple) == timestamp_to_convert
+
     with freeze_time(frozen, ignore=['_pytest', 'nose']):
         assert time.time() != expected_frozen
         # assert time.localtime() != expected_frozen_local
@@ -661,6 +668,9 @@ def test_should_use_real_time():
             assert time.clock() != expected_clock
         if HAS_TIME_NS:
             assert time.time_ns() != expected_frozen * 1e9
+
+        assert calendar.timegm(time.gmtime()) != expected_frozen
+        assert calendar.timegm(time_tuple) == timestamp_to_convert
 
 
 @pytest.mark.skipif(not HAS_TIME_NS,

--- a/tests/test_datetimes.py
+++ b/tests/test_datetimes.py
@@ -1,5 +1,4 @@
 import time
-import calendar
 import datetime
 import unittest
 import locale
@@ -209,13 +208,6 @@ def test_time_gmtime():
         assert time_struct.tm_wday == 5
         assert time_struct.tm_yday == 14
         assert time_struct.tm_isdst == -1
-
-
-def test_calendar_timegm():
-    time_struct = time.gmtime()
-    assert calendar.timegm(time_struct) != 1326511294
-    with freeze_time('2012-01-14 03:21:34'):
-        assert calendar.timegm(time_struct) == 1326511294
 
 
 @pytest.mark.skipif(not HAS_CLOCK,
@@ -652,8 +644,6 @@ def test_should_use_real_time():
     from freezegun import api
     api.call_stack_inspection_limit = 100  # just to increase coverage
 
-    current_time = time.gmtime()
-
     with freeze_time(frozen):
         assert time.time() == expected_frozen
         # assert time.localtime() == expected_frozen_local
@@ -663,8 +653,6 @@ def test_should_use_real_time():
         if HAS_TIME_NS:
             assert time.time_ns() == expected_frozen * 1e9
 
-        assert calendar.timegm(current_time) == expected_frozen
-
     with freeze_time(frozen, ignore=['_pytest', 'nose']):
         assert time.time() != expected_frozen
         # assert time.localtime() != expected_frozen_local
@@ -673,8 +661,6 @@ def test_should_use_real_time():
             assert time.clock() != expected_clock
         if HAS_TIME_NS:
             assert time.time_ns() != expected_frozen * 1e9
-
-        assert calendar.timegm(current_time) != expected_frozen
 
 
 @pytest.mark.skipif(not HAS_TIME_NS,


### PR DESCRIPTION
This reverts commit 011138dc548bcf77c237a9f4f334b2838aa9d10b.

Fixes #326 
Fixes #327 

`calendar.timegm` always takes a datetime-like tuple as parameter and returns the corresponding Unix timestamp. There is no need to change how this function works.
Ignoring the parameter that is given results in unexpected behaviour from Freezegun.

Equivalent: `calendar.timegm(time.gmtime())`