### PR TITLE
Use environment markers for `python-dateutil`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,20 +1,16 @@
 #!/usr/bin/env python
 
-import sys
 from setuptools import setup
 
-requires = ['six']
+requires = [
+    'six',
+    'python-dateutil>1.0,!=2.0; python_version<"3"',
+    'python-dateutil>=2.7; python_version>="3"',
+]
 tests_require = [
     'mock;python_version<"3.4"',
     'nose'
 ]
-
-if sys.version_info.major == 2:
-    requires += ['python-dateutil>=1.0, != 2.0']
-else:
-    # Py3k
-    requires += ['python-dateutil>=2.7']
-
 
 with open('README.rst') as f:
     readme = f.read()


### PR DESCRIPTION
Currently `python-dateutil`'s version bounds are set when the wheel is built, which results in `python-dateutil>=1.0, != 2.0` being used for all pythons. We can see this when `pip install`ing the wheel on python3

```console
$ python3 --version
Python 3.6.10
$ python3 -m pip install freezegun
Looking in indexes: https://pypi.org/simple, https://pypi.lyft.net/pypi/
Collecting freezegun
  Using cached https://files.pythonhosted.org/packages/17/5d/1b9d6d3c7995fff473f35861d674e0113a5f0bd5a72fe0199c3f254665c7/freezegun-0.3.15-py2.py3-none-any.whl
Collecting python-dateutil!=2.0,>=1.0 (from freezegun)
  Using cached https://files.pythonhosted.org/packages/d4/70/d60450c3dd48ef87586924207ae8907090de0b306af2bce5d134d78615cb/python_dateutil-2.8.1-py2.py3-none-any.whl
Requirement already satisfied: six in /Users/mxr/.pyenv/versions/3.6.10/envs/py3.6.10/lib/python3.6/site-packages (from freezegun) (1.14.0)
Installing collected packages: python-dateutil, freezegun
Successfully installed freezegun-0.3.15 python-dateutil-2.8.1
```

(specifically the line `Collecting python-dateutil!=2.0,>=1.0 (from freezegun)`)

To fix this we can use environment markers which will properly choose the right version at install time. This is the same technique used for `mock` in this file, too.