### PR TITLE
Fix CI by specifying `pytest` lower bound

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ coverage
 pytest-coverage
 coveralls
 mock
-pytest
+pytest>=4.6
 maya; python_version == '2.7' or python_version >= '3.6'


### PR DESCRIPTION
```
pluggy.manager.PluginValidationError: Plugin 'pytest_cov' could not be loaded: (pytest 4.3.1 (/home/travis/virtualenv/python3.6.7/lib/python3.6/site-packages), Requirement.parse('pytest>=4.6'))!
```