### PR TITLE
Fix duplicate test names

### DIFF
--- a/tests/test_datetimes.py
+++ b/tests/test_datetimes.py
@@ -491,12 +491,12 @@ class TestUnitTestMethodDecorator(unittest.TestCase):
         self.assertEqual(datetime.date(2013, 4, 9), datetime.date.today())
 
     @freeze_time('2013-04-09', as_kwarg='frozen_time')
-    def test_method_decorator_works_on_unittest(self, frozen_time):
+    def test_method_decorator_works_on_unittest_kwarg_frozen_time(self, frozen_time):
         self.assertEqual(datetime.date(2013, 4, 9), datetime.date.today())
         self.assertEqual(datetime.date(2013, 4, 9), frozen_time.time_to_freeze.today())
 
     @freeze_time('2013-04-09', as_kwarg='hello')
-    def test_method_decorator_works_on_unittest(self, **kwargs):
+    def test_method_decorator_works_on_unittest_kwarg_hello(self, **kwargs):
         self.assertEqual(datetime.date(2013, 4, 9), datetime.date.today())
         self.assertEqual(datetime.date(2013, 4, 9), kwargs.get('hello').time_to_freeze.today())
 


### PR DESCRIPTION
3 tests have the same name so pytest will only run one of them

Before:

```console
$ pytest -k TestUnitTestMethodDecorator --collect-only tests/test_datetimes.py
=============================================== test session starts ===============================================
platform darwin -- Python 3.6.10, pytest-5.4.2, py-1.8.1, pluggy-0.13.1
rootdir: /Users/mxr/src/go/src/github.com/mxr/freezegun
plugins: mock-3.1.0, cov-2.8.1
collected 63 items / 62 deselected / 1 selected
<Package /Users/mxr/src/go/src/github.com/mxr/freezegun/tests>
  <Module test_datetimes.py>
    <UnitTestCase TestUnitTestMethodDecorator>
      <TestCaseFunction test_method_decorator_works_on_unittest>
```

After

```console
$ pytest -k TestUnitTestMethodDecorator --collect-only tests/test_datetimes.py
=============================================== test session starts ===============================================
platform darwin -- Python 3.6.10, pytest-5.4.2, py-1.8.1, pluggy-0.13.1
rootdir: /Users/mxr/src/go/src/github.com/mxr/freezegun
plugins: mock-3.1.0, cov-2.8.1
collected 65 items / 62 deselected / 3 selected
<Package /Users/mxr/src/go/src/github.com/mxr/freezegun/tests>
  <Module test_datetimes.py>
    <UnitTestCase TestUnitTestMethodDecorator>
      <TestCaseFunction test_method_decorator_works_on_unittest>
      <TestCaseFunction test_method_decorator_works_on_unittest_kwarg_frozen_time>
      <TestCaseFunction test_method_decorator_works_on_unittest_kwarg_hello>
```

Identified with `flake8`:

```console
$ flake8 2>&1 | grep F811
./tests/test_datetimes.py:493:5: F811 redefinition of unused 'test_method_decorator_works_on_unittest' from line 489
./tests/test_datetimes.py:498:5: F811 redefinition of unused 'test_method_decorator_works_on_unittest' from line 493
```