### PR TITLE
Travis CI: Test on Python 3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
   - 3.6
   - 3.7
   - 3.8
-  - 3.9-dev
+  - 3.9
   - pypy3
 
 script: make travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
   - 3.6
   - 3.7
   - 3.8
+  - 3.9-dev
   - pypy3
 
 script: make travis


### PR DESCRIPTION
Python 3.9 is in beta with final 3.9.0 release due in October.

* https://www.python.org/dev/peps/pep-0596/

Test now on 3.9-dev to prevent surprises at release.