### PR TITLE
Hack for github/markup rendering SVG image badges

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 FreezeGun: Let your Python tests travel through time
 ====================================================
 
-.. image:: https://img.shields.io/pypi/v/freezegun.svg
+.. image:: https://img.shields.io/pypi/v/freezegun.svg#foo
    :target: https://pypi.python.org/pypi/freezegun/
 .. image:: https://secure.travis-ci.org/spulec/freezegun.svg?branch=master
    :target: https://travis-ci.org/spulec/freezegun


### PR DESCRIPTION
Github does not display well badges with SVG images as RST references. I've [opened a pull](https://github.com/github/markup/pull/1368) to solve this bug, but the project does not seems maintained.

You can note that hovering the PyPI version badge appends an underline after it like a link. Adding `#foo` after the link solves this.