### PR TITLE
Add support for `time.monotonic` (and `time.monotonic_ns`)

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -16,3 +16,4 @@ Patches and Suggestions
 - `James Lu <github.com/CrazyPython>`_
 - `Dan Elkis <github.com/rinslow>`_
 - `Bastien Vallet <github.com/djailla>`_
+- `Julian Mehnle <github.com/jmehnle>`_

--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ FreezeGun is a library that allows your Python tests to travel through time by m
 Usage
 -----
 
-Once the decorator or context manager have been invoked, all calls to datetime.datetime.now(), datetime.datetime.utcnow(), datetime.date.today(), time.time(), time.localtime(), time.gmtime(), and time.strftime() will return the time that has been frozen.
+Once the decorator or context manager have been invoked, all calls to datetime.datetime.now(), datetime.datetime.utcnow(), datetime.date.today(), time.time(), time.localtime(), time.gmtime(), and time.strftime() will return the time that has been frozen. time.monotonic() will also be frozen, but as usual it makes no guarantees about its absolute value, only its changes over time.
 
 Decorator
 ~~~~~~~~~
@@ -174,7 +174,7 @@ FreezeGun allows for the time to be manually forwarded as well.
 
 .. code-block:: python
 
-    def test_manual_increment():
+    def test_manual_tick():
         initial_datetime = datetime.datetime(year=1, month=7, day=12,
                                             hour=15, minute=6, second=3)
         with freeze_time(initial_datetime) as frozen_datetime:
@@ -187,6 +187,18 @@ FreezeGun allows for the time to be manually forwarded as well.
             frozen_datetime.tick(delta=datetime.timedelta(seconds=10))
             initial_datetime += datetime.timedelta(seconds=10)
             assert frozen_datetime() == initial_datetime
+
+.. code-block:: python
+
+    def test_monotonic_manual_tick():
+        initial_datetime = datetime.datetime(year=1, month=7, day=12,
+                                            hour=15, minute=6, second=3)
+        with freeze_time(initial_datetime) as frozen_datetime:
+            monotonic_t0 = time.monotonic()
+            frozen_datetime.tick(1.0)
+            monotonic_t1 = time.monotonic()
+            assert monotonic_t1 == monotonic_t0 + 1.0
+
 
 Moving time to specify datetime
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/test_ticking.py
+++ b/tests/test_ticking.py
@@ -62,6 +62,14 @@ def test_ticking_time():
         assert time.time() > 1326585599.0
 
 
+@utils.cpython_only
+def test_ticking_monotonic():
+    with freeze_time("Jan 14th, 2012, 23:59:59", tick=True):
+        initial_monotonic = time.monotonic()
+        time.sleep(0.001)  # Deal with potential clock resolution problems
+        assert time.monotonic() > initial_monotonic
+
+
 @mock.patch('freezegun.api._is_cpython', False)
 def test_pypy_compat():
     try:


### PR DESCRIPTION
There's a seemingly abandoned attempt at adding support for `time.monotonic` in https://github.com/spulec/freezegun/pull/199. As there were major changes to `freezegun` since then, I decided to take a fresh stab at implementing such support. It's worth noting that `time.monotonic` doesn't give many guarantees to begin with, so not many are tested.

I'd be happy to add a few documentation bits if this implementation and the accompanying tests work for you.