### PR TITLE
Allow to configure default ignore list

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -17,3 +17,4 @@ Patches and Suggestions
 - `Dan Elkis <github.com/rinslow>`_
 - `Bastien Vallet <github.com/djailla>`_
 - `Julian Mehnle <github.com/jmehnle>`_
+- `Lukasz Balcerzak <https://github.com/lukaszb>`_

--- a/README.rst
+++ b/README.rst
@@ -264,3 +264,48 @@ On Debian systems:
 .. code-block:: bash
 
     $ sudo apt-get install python-freezegun
+
+
+Ignore packages
+---------------
+
+Sometimes it's desired to ignore FreezeGun behaviour for particular packages (i.e. libraries).
+It's possible to ignore them for a single invocation:
+
+
+.. code-block:: python
+
+    from freezegun import freeze_time
+
+    with freeze_time('2020-10-06', ignore=['threading']):
+        # ...
+
+
+By default FreezeGun ignores following packages:
+
+.. code-block:: python
+
+    [
+        'nose.plugins',
+        'six.moves',
+        'django.utils.six.moves',
+        'google.gax',
+        'threading',
+        'Queue',
+        'selenium',
+        '_pytest.terminal.',
+        '_pytest.runner.',
+        'gi',
+    ]
+
+
+It's possible to set your own default ignore list:
+
+.. code-block:: python
+
+    import freezegun
+
+    freezegun.configure(default_ignore=['threading', 'tensorflow'])
+
+
+Please note this will override default ignore list.

--- a/README.rst
+++ b/README.rst
@@ -305,7 +305,14 @@ It's possible to set your own default ignore list:
 
     import freezegun
 
-    freezegun.configure(default_ignore=['threading', 'tensorflow'])
+    freezegun.configure(default_ignore_list=['threading', 'tensorflow'])
 
 
-Please note this will override default ignore list.
+Please note this will override default ignore list. If you want to extend existing defaults
+please use:
+
+.. code-block:: python
+
+    import freezegun
+
+    freezegun.configure(extend_ignore_list=['tensorflow'])

--- a/freezegun/__init__.py
+++ b/freezegun/__init__.py
@@ -7,6 +7,7 @@ freezegun
 
 """
 from .api import freeze_time
+from .config import configure
 
 __title__ = 'freezegun'
 __version__ = '1.0.0'
@@ -15,4 +16,4 @@ __license__ = 'Apache License 2.0'
 __copyright__ = 'Copyright 2012 Steve Pulec'
 
 
-__all__ = ["freeze_time"]
+__all__ = ["freeze_time", "configure"]

--- a/freezegun/api.py
+++ b/freezegun/api.py
@@ -810,8 +810,8 @@ def freeze_time(time_to_freeze=None, tz_offset=0, ignore=None, tick=False, as_ar
     if ignore is None:
         ignore = []
     ignore = ignore[:]
-    if config.settings.default_ignore:
-        ignore.extend(config.settings.default_ignore)
+    if config.settings.default_ignore_list:
+        ignore.extend(config.settings.default_ignore_list)
 
     return _freeze_time(
         time_to_freeze_str=time_to_freeze,

--- a/freezegun/api.py
+++ b/freezegun/api.py
@@ -1,3 +1,4 @@
+from . import config
 import dateutil
 import datetime
 import functools
@@ -809,19 +810,18 @@ def freeze_time(time_to_freeze=None, tz_offset=0, ignore=None, tick=False, as_ar
     if ignore is None:
         ignore = []
     ignore = ignore[:]
-    ignore.extend(['nose.plugins',
-        'six.moves',
-        'django.utils.six.moves',
-        'google.gax',
-        'threading',
-        'Queue',
-        'selenium',
-        '_pytest.terminal.',
-        '_pytest.runner.',
-        'gi',
-    ])
+    if config.settings.default_ignore:
+        ignore.extend(config.settings.default_ignore)
 
-    return _freeze_time(time_to_freeze, tz_offset, ignore, tick, as_arg, as_kwarg, auto_tick_seconds)
+    return _freeze_time(
+        time_to_freeze_str=time_to_freeze,
+        tz_offset=tz_offset,
+        ignore=ignore,
+        tick=tick,
+        as_arg=as_arg,
+        as_kwarg=as_kwarg,
+        auto_tick_seconds=auto_tick_seconds,
+    )
 
 
 # Setup adapters for sqlite

--- a/freezegun/config.py
+++ b/freezegun/config.py
@@ -1,6 +1,6 @@
 
 
-DEFAULT_IGNORE = [
+DEFAULT_IGNORE_LIST = [
     'nose.plugins',
     'six.moves',
     'django.utils.six.moves',
@@ -15,12 +15,26 @@ DEFAULT_IGNORE = [
 
 
 class Settings:
-    def __init__(self, default_ignore=None):
-        self.default_ignore = default_ignore or DEFAULT_IGNORE[:]
+    def __init__(self, default_ignore_list=None):
+        self.default_ignore_list = default_ignore_list or DEFAULT_IGNORE_LIST[:]
 
 
 settings = Settings()
 
 
-def configure(default_ignore=None):
-    settings.default_ignore = default_ignore
+class ConfigurationError(Exception):
+    pass
+
+
+def configure(default_ignore_list=None, extend_ignore_list=None):
+    if default_ignore_list is not None and extend_ignore_list is not None:
+        raise ConfigurationError("Either default_ignore_list or extend_ignore_list might be given, not both")
+    if default_ignore_list:
+        settings.default_ignore_list = default_ignore_list
+    if extend_ignore_list:
+        settings.default_ignore_list = [*settings.default_ignore_list, *extend_ignore_list]
+
+
+def reset_config():
+    global settings
+    settings = Settings()

--- a/freezegun/config.py
+++ b/freezegun/config.py
@@ -1,0 +1,26 @@
+
+
+DEFAULT_IGNORE = [
+    'nose.plugins',
+    'six.moves',
+    'django.utils.six.moves',
+    'google.gax',
+    'threading',
+    'Queue',
+    'selenium',
+    '_pytest.terminal.',
+    '_pytest.runner.',
+    'gi',
+]
+
+
+class Settings:
+    def __init__(self, default_ignore=None):
+        self.default_ignore = default_ignore or DEFAULT_IGNORE[:]
+
+
+settings = Settings()
+
+
+def configure(default_ignore=None):
+    settings.default_ignore = default_ignore

--- a/tests/test_configure.py
+++ b/tests/test_configure.py
@@ -1,0 +1,29 @@
+from unittest import mock
+import freezegun
+
+
+def teardown_function():
+    freezegun.configure(default_ignore=None)
+
+
+def test_default_ignore_is_overridden():
+    freezegun.configure(default_ignore=['threading', 'tensorflow'])
+
+    with mock.patch("freezegun.api._freeze_time.__init__", return_value=None) as _freeze_time_init_mock:
+
+        freezegun.freeze_time("2020-10-06")
+
+        expected_ignore_list = [
+            'threading',
+            'tensorflow',
+        ]
+
+        _freeze_time_init_mock.assert_called_once_with(
+            time_to_freeze_str="2020-10-06",
+            tz_offset=0,
+            ignore=expected_ignore_list,
+            tick=False,
+            as_arg=False,
+            as_kwarg='',
+            auto_tick_seconds=0,
+        )

--- a/tests/test_configure.py
+++ b/tests/test_configure.py
@@ -1,13 +1,18 @@
 from unittest import mock
 import freezegun
+import freezegun.config
+
+
+def setup_function():
+    freezegun.config.reset_config()
 
 
 def teardown_function():
-    freezegun.configure(default_ignore=None)
+    freezegun.config.reset_config()
 
 
-def test_default_ignore_is_overridden():
-    freezegun.configure(default_ignore=['threading', 'tensorflow'])
+def test_default_ignore_list_is_overridden():
+    freezegun.configure(default_ignore_list=['threading', 'tensorflow'])
 
     with mock.patch("freezegun.api._freeze_time.__init__", return_value=None) as _freeze_time_init_mock:
 
@@ -15,6 +20,37 @@ def test_default_ignore_is_overridden():
 
         expected_ignore_list = [
             'threading',
+            'tensorflow',
+        ]
+
+        _freeze_time_init_mock.assert_called_once_with(
+            time_to_freeze_str="2020-10-06",
+            tz_offset=0,
+            ignore=expected_ignore_list,
+            tick=False,
+            as_arg=False,
+            as_kwarg='',
+            auto_tick_seconds=0,
+        )
+
+def test_extend_default_ignore_list():
+    freezegun.configure(extend_ignore_list=['tensorflow'])
+
+    with mock.patch("freezegun.api._freeze_time.__init__", return_value=None) as _freeze_time_init_mock:
+
+        freezegun.freeze_time("2020-10-06")
+
+        expected_ignore_list = [
+            'nose.plugins',
+            'six.moves',
+            'django.utils.six.moves',
+            'google.gax',
+            'threading',
+            'Queue',
+            'selenium',
+            '_pytest.terminal.',
+            '_pytest.runner.',
+            'gi',
             'tensorflow',
         ]
 

--- a/tox.ini
+++ b/tox.ini
@@ -7,5 +7,5 @@
 envlist = py35, py36, py37, py38, pypy3
 
 [testenv]
-commands = pytest --cov
+commands = pytest --cov {posargs}
 deps = -rrequirements.txt


### PR DESCRIPTION
Backstory: some tests started to fail with some cryptic errors. Ended up it started happening after adding `tenserflow` package. Now we need to somehow remember to always ignore it or create wrapper around `freeze_time` calls.

With ability to configure default ignore list it would be much simpler.

Let me know if this makes sense.