### PR TITLE
Fix freezegun when accessing from thread after stop()

### DIFF
--- a/freezegun/api.py
+++ b/freezegun/api.py
@@ -167,6 +167,10 @@ def _should_use_real_time():
     if not call_stack_inspection_limit:
         return False
 
+    # Means stop() has already been called, so we can now return the real time
+    if not ignore_lists:
+        return True
+
     if not ignore_lists[-1]:
         return False
 


### PR DESCRIPTION
There is more context on issue #345.

This branch checks if `ignore_lists` is empty before checking the last element. If it is empty, means `close()` has already been called, and we should return the real time.

This only happens when a thread is created, since `ignore_lists` is a global variable.