### PR TITLE
Support selective patching

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ FreezeGun is a library that allows your Python tests to travel through time by m
 Usage
 -----
 
-Once the decorator or context manager have been invoked, all calls to datetime.datetime.now(), datetime.datetime.utcnow(), datetime.date.today(), time.time(), time.localtime(), time.gmtime(), and time.strftime() will return the time that has been frozen. time.monotonic() will also be frozen, but as usual it makes no guarantees about its absolute value, only its changes over time.
+Once the decorator or context manager have been invoked, all calls to datetime.datetime.now(), datetime.datetime.utcnow(), datetime.date.today(), time.time(), time.localtime(), time.gmtime(), and time.strftime() will return the time that has been frozen. time.monotonic() (and time.monotonic_ns()) are not frozen by default and it makes no guarantees about its absolute value, only its changes over time.
 
 Decorator
 ~~~~~~~~~
@@ -193,7 +193,7 @@ FreezeGun allows for the time to be manually forwarded as well.
     def test_monotonic_manual_tick():
         initial_datetime = datetime.datetime(year=1, month=7, day=12,
                                             hour=15, minute=6, second=3)
-        with freeze_time(initial_datetime) as frozen_datetime:
+        with freeze_time_with_monotonic(initial_datetime) as frozen_datetime:
             monotonic_t0 = time.monotonic()
             frozen_datetime.tick(1.0)
             monotonic_t1 = time.monotonic()
@@ -316,3 +316,25 @@ please use:
     import freezegun
 
     freezegun.configure(extend_ignore_list=['tensorflow'])
+
+
+Selective freezing
+------------------
+
+By default, `freeze_time` ignores monotonic time freezing to avoid possibly
+unexpected behaviour in asynchronous and other settings. To freeze it anyway, one
+can use `freeze_time_with_monotonic()` or provide a sequence-like `targets` argument
+to `freeze_time()` using the `Target` enum:
+
+.. code-block:: python
+
+    from freezegun import freeze_time, freeze_time_with_monotonic, Target, TargetsAll
+
+    with freeze_time_with_monotonic('2020-10-06'):
+        # ...
+
+    with freeze_time('2020-10-06', targets=TargetsAll):
+        # ...
+
+    with freeze_time('2020-10-06', targets=(Target.TIME, Target.DATETIME)):
+        # ...

--- a/freezegun/__init__.py
+++ b/freezegun/__init__.py
@@ -6,7 +6,9 @@ freezegun
 :copyright: (c) 2012 by Steve Pulec.
 
 """
-from .api import freeze_time
+from .api import (
+    freeze_time, freeze_time_with_monotonic, Target, TargetsAll, TargetsDefault,
+)
 from .config import configure
 
 __title__ = 'freezegun'
@@ -16,4 +18,8 @@ __license__ = 'Apache License 2.0'
 __copyright__ = 'Copyright 2012 Steve Pulec'
 
 
-__all__ = ["freeze_time", "configure"]
+__all__ = [
+    "freeze_time", "freeze_time_with_monotonic",
+    "Target", "TargetsAll", "TargetsDefault",
+    "configure"
+]

--- a/freezegun/api.py
+++ b/freezegun/api.py
@@ -858,6 +858,9 @@ def freeze_time(time_to_freeze=None, tz_offset=0, ignore=None, tick=False, as_ar
     )
 
 
+freeze_time_with_monotonic = functools.partial(freeze_time, targets=TargetsAll)
+
+
 # Setup adapters for sqlite
 try:
     # noinspection PyUnresolvedReferences

--- a/freezegun/api.py
+++ b/freezegun/api.py
@@ -1,3 +1,5 @@
+from enum import Enum
+
 from . import config
 import dateutil
 import datetime
@@ -539,9 +541,30 @@ class StepTickTimeFactory(object):
         self.tick(delta=delta)
 
 
+class Target(str, Enum):
+    DATE = 'date'
+    DATETIME = 'datetime'
+    GMTIME = 'gmtime'
+    LOCALTIME = 'localtime'
+    MONOTONIC = 'monotonic'
+    STRFTIME = 'strftime'
+    TIME = 'time'
+    TIME_NS = 'time_ns'
+    MONOTONIC_NS = 'monotonic_ns'
+    CLOCK = 'clock'
+
+
+TargetsDefault = frozenset(
+    target
+    for target in Target
+    if target not in (Target.MONOTONIC, Target.MONOTONIC_NS)
+)
+TargetsAll = frozenset(Target)
+
+
 class _freeze_time(object):
 
-    def __init__(self, time_to_freeze_str, tz_offset, ignore, tick, as_arg, as_kwarg, auto_tick_seconds):
+    def __init__(self, time_to_freeze_str, tz_offset, ignore, tick, as_arg, as_kwarg, auto_tick_seconds, targets):
         self.time_to_freeze = _parse_time_to_freeze(time_to_freeze_str)
         self.tz_offset = _parse_tz_offset(tz_offset)
         self.ignore = tuple(ignore)
@@ -551,6 +574,7 @@ class _freeze_time(object):
         self.modules_at_start = set()
         self.as_arg = as_arg
         self.as_kwarg = as_kwarg
+        self.targets = targets
 
     def __call__(self, func):
         if inspect.isclass(func):
@@ -633,45 +657,50 @@ class _freeze_time(object):
             return freeze_factory
 
         # Change the modules
-        datetime.datetime = FakeDatetime
-        datetime.date = FakeDate
+        to_patch = []
 
-        time.time = fake_time
-        time.monotonic = fake_monotonic
-        time.localtime = fake_localtime
-        time.gmtime = fake_gmtime
-        time.strftime = fake_strftime
+        if Target.DATETIME in self.targets:
+            datetime.datetime = FakeDatetime
+            to_patch.append(('real_datetime', real_datetime, FakeDatetime))
+            copyreg.dispatch_table[real_datetime] = pickle_fake_datetime
+        if Target.DATE in self.targets:
+            datetime.date = FakeDate
+            to_patch.append(('real_date', real_date, FakeDate))
+            copyreg.dispatch_table[real_date] = pickle_fake_date
+
+        if Target.TIME in self.targets:
+            time.time = fake_time
+            to_patch.append(('real_time', real_time, fake_time))
+        if Target.MONOTONIC in self.targets:
+            time.monotonic = fake_monotonic
+            to_patch.append(('real_monotonic', real_monotonic, fake_monotonic))
+        if Target.LOCALTIME in self.targets:
+            time.localtime = fake_localtime
+            to_patch.append(('real_localtime', real_localtime, fake_localtime))
+        if Target.GMTIME in self.targets:
+            time.gmtime = fake_gmtime
+            to_patch.append(('real_gmtime', real_gmtime, fake_gmtime))
+        if Target.STRFTIME in self.targets:
+            time.strftime = fake_strftime
+            to_patch.append(('real_strftime', real_strftime, fake_strftime))
+
+        if _TIME_NS_PRESENT and Target.TIME_NS in self.targets:
+            time.time_ns = fake_time_ns
+            to_patch.append(('real_time_ns', real_time_ns, fake_time_ns))
+        if _MONOTONIC_NS_PRESENT and Target.MONOTONIC_NS in self.targets:
+            time.monotonic_ns = fake_monotonic_ns
+            to_patch.append(('real_monotonic_ns', real_monotonic_ns, fake_monotonic_ns))
+        if real_clock is not None and Target.CLOCK in self.targets:
+            # time.clock is deprecated and was removed in Python 3.8
+            time.clock = fake_clock
+            to_patch.append(('real_clock', real_clock, fake_clock))
+
         if uuid_generate_time_attr:
             setattr(uuid, uuid_generate_time_attr, None)
         uuid._UuidCreate = None
         uuid._last_timestamp = None
 
-        copyreg.dispatch_table[real_datetime] = pickle_fake_datetime
-        copyreg.dispatch_table[real_date] = pickle_fake_date
-
         # Change any place where the module had already been imported
-        to_patch = [
-            ('real_date', real_date, FakeDate),
-            ('real_datetime', real_datetime, FakeDatetime),
-            ('real_gmtime', real_gmtime, fake_gmtime),
-            ('real_localtime', real_localtime, fake_localtime),
-            ('real_monotonic', real_monotonic, fake_monotonic),
-            ('real_strftime', real_strftime, fake_strftime),
-            ('real_time', real_time, fake_time),
-        ]
-
-        if _TIME_NS_PRESENT:
-            time.time_ns = fake_time_ns
-            to_patch.append(('real_time_ns', real_time_ns, fake_time_ns))
-
-        if _MONOTONIC_NS_PRESENT:
-            time.monotonic_ns = fake_monotonic_ns
-            to_patch.append(('real_monotonic_ns', real_monotonic_ns, fake_monotonic_ns))
-
-        if real_clock is not None:
-            # time.clock is deprecated and was removed in Python 3.8
-            time.clock = fake_clock
-            to_patch.append(('real_clock', real_clock, fake_clock))
 
         self.fake_names = tuple(fake.__name__ for real_name, real, fake in to_patch)
         self.reals = {id(fake): real for real_name, real, fake in to_patch}
@@ -710,8 +739,8 @@ class _freeze_time(object):
         if not freeze_factories:
             datetime.datetime = real_datetime
             datetime.date = real_date
-            copyreg.dispatch_table.pop(real_datetime)
-            copyreg.dispatch_table.pop(real_date)
+            copyreg.dispatch_table.pop(real_datetime, None)
+            copyreg.dispatch_table.pop(real_date, None)
             for module, module_attribute, original_value in self.undo_changes:
                 setattr(module, module_attribute, original_value)
             self.undo_changes = []
@@ -787,7 +816,7 @@ class _freeze_time(object):
 
 
 def freeze_time(time_to_freeze=None, tz_offset=0, ignore=None, tick=False, as_arg=False, as_kwarg='',
-                auto_tick_seconds=0):
+                auto_tick_seconds=0, targets=TargetsDefault):
     acceptable_times = (type(None), _string_type, datetime.date, datetime.timedelta,
              types.FunctionType, types.GeneratorType)
 
@@ -802,14 +831,14 @@ def freeze_time(time_to_freeze=None, tz_offset=0, ignore=None, tick=False, as_ar
         raise SystemError('Calling freeze_time with tick=True is only compatible with CPython')
 
     if isinstance(time_to_freeze, types.FunctionType):
-        return freeze_time(time_to_freeze(), tz_offset, ignore, tick, auto_tick_seconds)
+        return freeze_time(time_to_freeze(), tz_offset, ignore, tick, auto_tick_seconds, targets)
 
     if isinstance(time_to_freeze, types.GeneratorType):
-        return freeze_time(next(time_to_freeze), tz_offset, ignore, tick, auto_tick_seconds)
+        return freeze_time(next(time_to_freeze), tz_offset, ignore, tick, auto_tick_seconds, targets)
 
     if MayaDT is not None and isinstance(time_to_freeze, MayaDT):
         return freeze_time(time_to_freeze.datetime(), tz_offset, ignore,
-                           tick, as_arg)
+                           tick, as_arg, targets)
 
     if ignore is None:
         ignore = []
@@ -825,6 +854,7 @@ def freeze_time(time_to_freeze=None, tz_offset=0, ignore=None, tick=False, as_ar
         as_arg=as_arg,
         as_kwarg=as_kwarg,
         auto_tick_seconds=auto_tick_seconds,
+        targets=targets,
     )
 
 

--- a/freezegun/api.py
+++ b/freezegun/api.py
@@ -574,7 +574,7 @@ class _freeze_time(object):
         self.modules_at_start = set()
         self.as_arg = as_arg
         self.as_kwarg = as_kwarg
-        self.targets = targets
+        self.targets = frozenset(map(Target, targets))
 
     def __call__(self, func):
         if inspect.isclass(func):

--- a/tests/test_datetimes.py
+++ b/tests/test_datetimes.py
@@ -11,7 +11,7 @@ import pytest
 from tests import utils
 
 from freezegun import freeze_time
-from freezegun.api import FakeDatetime, FakeDate
+from freezegun.api import FakeDatetime, FakeDate, TargetsAll
 
 try:
     import maya
@@ -205,7 +205,7 @@ def test_bad_time_argument():
 def test_time_monotonic():
     initial_datetime = datetime.datetime(year=1, month=7, day=12,
                                         hour=15, minute=6, second=3)
-    with freeze_time(initial_datetime) as frozen_datetime:
+    with freeze_time(initial_datetime, targets=TargetsAll) as frozen_datetime:
         monotonic_t0 = time.monotonic()
         if HAS_MONOTONIC_NS:
             monotonic_ns_t0 = time.monotonic_ns()
@@ -680,7 +680,7 @@ def test_time_with_nested():
 def test_monotonic_with_nested():
     from time import monotonic
 
-    with freeze_time('2015-01-01') as frozen_datetime_1:
+    with freeze_time('2015-01-01', targets=TargetsAll) as frozen_datetime_1:
         initial_monotonic_1 = time.monotonic()
         with freeze_time('2015-12-25') as frozen_datetime_2:
             initial_monotonic_2 = time.monotonic()

--- a/tests/test_target.py
+++ b/tests/test_target.py
@@ -1,0 +1,66 @@
+import datetime
+import time
+
+import pytest
+
+from freezegun import freeze_time
+from freezegun.api import (
+    Target, real_date, real_datetime, FakeDate, FakeDatetime, real_gmtime,
+    fake_gmtime, real_localtime, fake_localtime, fake_monotonic, real_monotonic,
+    real_strftime, fake_strftime, real_time, fake_time,
+)
+
+HAS_TIME_NS = hasattr(time, 'time_ns')
+HAS_MONOTONIC_NS = hasattr(time, 'monotonic_ns')
+HAS_CLOCK = hasattr(time, 'clock')
+
+TARGETS = [
+    (Target.DATE, datetime, real_date, FakeDate),
+    (Target.DATETIME, datetime, real_datetime, FakeDatetime),
+    (Target.GMTIME, time, real_gmtime, fake_gmtime),
+    (Target.LOCALTIME, time, real_localtime, fake_localtime),
+    (Target.MONOTONIC, time, real_monotonic, fake_monotonic),
+    (Target.STRFTIME, time, real_strftime, fake_strftime),
+    (Target.TIME, time, real_time, fake_time),
+]
+if HAS_TIME_NS:
+    from freezegun.api import real_time_ns, fake_time_ns
+    TARGETS.append((Target.TIME_NS, time, real_time_ns, fake_time_ns))
+if HAS_MONOTONIC_NS:
+    from freezegun.api import real_monotonic_ns, fake_monotonic_ns
+    TARGETS.append((Target.MONOTONIC_NS, time, real_monotonic_ns, fake_monotonic_ns))
+if HAS_CLOCK:
+    from freezegun.api import real_clock, fake_clock
+    TARGETS.append((Target.CLOCK, time, real_clock, fake_clock))
+
+
+@pytest.mark.parametrize(
+    'target_to_patch,expected',
+    (
+        (target, fake)
+        for (target, _, _, fake) in TARGETS
+    )
+)
+def test_target(target_to_patch, expected):
+    assert TARGETS
+    with freeze_time(targets={target_to_patch}):
+        for target, module, real, fake in TARGETS:
+            assert getattr(module, target) == (
+                real if target != target_to_patch else fake
+            )
+
+    for target, module, real, fake in TARGETS:
+        assert getattr(module, target) == real
+
+
+def test_default_targets():
+    with freeze_time():
+        for target, module, real, fake in TARGETS:
+            assert getattr(module, target) == (
+                fake
+                if target not in (Target.MONOTONIC, Target.MONOTONIC_NS)
+                else real
+            )
+
+    for target, module, real, fake in TARGETS:
+        assert getattr(module, target) == real

--- a/tests/test_target.py
+++ b/tests/test_target.py
@@ -74,3 +74,8 @@ def test_freeze_time_with_monotonic():
 
     for target, module, real, fake in TARGETS:
         assert getattr(module, target) == real
+
+
+def test_invalid_target():
+    with pytest.raises(ValueError, match="'invalid' is not a valid Target"):
+        freeze_time(targets=('invalid',))

--- a/tests/test_target.py
+++ b/tests/test_target.py
@@ -8,6 +8,7 @@ from freezegun.api import (
     Target, real_date, real_datetime, FakeDate, FakeDatetime, real_gmtime,
     fake_gmtime, real_localtime, fake_localtime, fake_monotonic, real_monotonic,
     real_strftime, fake_strftime, real_time, fake_time,
+    freeze_time_with_monotonic,
 )
 
 HAS_TIME_NS = hasattr(time, 'time_ns')
@@ -61,6 +62,15 @@ def test_default_targets():
                 if target not in (Target.MONOTONIC, Target.MONOTONIC_NS)
                 else real
             )
+
+    for target, module, real, fake in TARGETS:
+        assert getattr(module, target) == real
+
+
+def test_freeze_time_with_monotonic():
+    with freeze_time_with_monotonic():
+        for target, module, real, fake in TARGETS:
+            assert getattr(module, target) == fake
 
     for target, module, real, fake in TARGETS:
         assert getattr(module, target) == real


### PR DESCRIPTION
Motivated by #384 - implicit monotonic time patching may (and does) cause hard-to-debug problems in various settings.

- Add `Target` enum describing functions that can be patched;
- Pass `targets` parameter to `freeze_time` to describe functions to be patched;
- Make `targets` exclude monotonic time by default;
- Add `freeze_time_with_monotonic` helper to include monotonic time patching.