### PR TITLE
check _should_use_real_time() in classmethod/staticmethod of FakeDate/FakeDatetime

### DIFF
--- a/freezegun/api.py
+++ b/freezegun/api.py
@@ -416,7 +416,7 @@ class FakeDatetime(with_metaclass(FakeDatetimeMeta, real_datetime, FakeDate)):
         if self.tzinfo is None:
             if _should_use_real_time():
                 # access naive datetime out of freeze_time, thus fallback to local timezone
-                tz_offset = tzlocal.utcoffset(self)
+                tz_offset = tzlocal().utcoffset(self)
             else:
                 tz_offset = self._tz_offset()
             return (self - _EPOCH - tz_offset).total_seconds()

--- a/freezegun/api.py
+++ b/freezegun/api.py
@@ -452,7 +452,7 @@ class FakeDatetime(with_metaclass(FakeDatetimeMeta, real_datetime, FakeDate)):
     @classmethod
     def utcnow(cls):
         if _should_use_real_time():
-            real_datetime.utcnow()
+            return real_datetime.utcnow()
 
         result = cls._time_to_freeze()
         return datetime_to_fakedatetime(result)


### PR DESCRIPTION
This PR follows up #374.

Even after `stop()` is called, FakeDate/FakeDatetime instances can still exists and causes `IndexError`.