### PR TITLE
add missing classifiers and tox envs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py35, py36, py37, py38, pypy3
+envlist = py35, py36, py37, py38, py39, pypy3
 
 [testenv]
 commands = pytest --cov {posargs}


### PR DESCRIPTION
Hi :wave: 

big thanks for developing such a great package!

This PR simply adds missing trove classifier and tox env for python 3.9