### PR TITLE
feat(api.py): Add tick() to TickingDateTimeFactory

### DIFF
--- a/freezegun/api.py
+++ b/freezegun/api.py
@@ -490,6 +490,13 @@ class TickingDateTimeFactory(object):
     def __call__(self):
         return self.time_to_freeze + (real_datetime.now() - self.start)
 
+    def tick(self, delta=datetime.timedelta(seconds=1)):
+        if isinstance(delta, numbers.Real):
+            # noinspection PyTypeChecker
+            self.time_to_freeze += datetime.timedelta(seconds=delta)
+        else:
+            self.time_to_freeze += delta
+
 
 class FrozenDateTimeFactory(object):
 


### PR DESCRIPTION
It would be nice to be able to manually tick, when tick=True.

I think it probably makes sense to combine `TickingDateTimeFactory` and `FrozenDateTimeFactory` into one and just have an argument whether time should naturally advance, but tests don't work properly for me, so I don't want to change too much.