### PR TITLE
Add support for perf_counter

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,11 @@
 Freezegun Changelog
 ===================
 
+1.2.0
+-----
+
+* Add support for `time.perf_counter` (and `…_ns`)
+
 1.1.0
 -----
 

--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ FreezeGun is a library that allows your Python tests to travel through time by m
 Usage
 -----
 
-Once the decorator or context manager have been invoked, all calls to datetime.datetime.now(), datetime.datetime.utcnow(), datetime.date.today(), time.time(), time.localtime(), time.gmtime(), and time.strftime() will return the time that has been frozen. time.monotonic() will also be frozen, but as usual it makes no guarantees about its absolute value, only its changes over time.
+Once the decorator or context manager have been invoked, all calls to datetime.datetime.now(), datetime.datetime.utcnow(), datetime.date.today(), time.time(), time.localtime(), time.gmtime(), and time.strftime() will return the time that has been frozen. time.monotonic() and time.perf_counter() will also be frozen, but as usual it makes no guarantees about their absolute value, only their changes over time.
 
 Decorator
 ~~~~~~~~~

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -3,6 +3,8 @@ from unittest import SkipTest
 
 from freezegun.api import FakeDate, FakeDatetime, _is_cpython
 
+import pytest
+
 
 def is_fake_date(obj):
     return obj.__class__ is FakeDate
@@ -10,6 +12,11 @@ def is_fake_date(obj):
 
 def is_fake_datetime(obj):
     return obj.__class__ is FakeDatetime
+
+
+cpython_only_mark = pytest.mark.skipif(
+    not _is_cpython,
+    reason="Requires CPython")
 
 
 def cpython_only(func):


### PR DESCRIPTION
`time.perf_counter` and `time.monotonic` are similar clocks (on many platforms they are actually the *same* clock), with the main difference between them being that if a system has a higher resolution monotonic clock than the one that `time.monotonic()` calls, it will be used for `time.perf_counter()`.

This commit adds support for `time.perf_counter()` and `time.perf_counter_ns()` and refactors `monotonic()` and `monotonic_ns()` so that these similar functions can share an implementation.

It also refactors some of the tests around `monotonic()` and `monotonic_ns()` so that the same tests can be used for `perf_counter(_ns)` as well.