### PR TITLE
Fix decorate_class for Python 3.10 where staticmethod is callable.

### DIFF
--- a/freezegun/api.py
+++ b/freezegun/api.py
@@ -598,7 +598,10 @@ class _freeze_time(object):
                         continue
                     seen.add(attr)
 
-                    if not callable(attr_value) or inspect.isclass(attr_value):
+                    # staticmethods are callable from Python 3.10 . Hence skip them from decoration
+                    if (not callable(attr_value)
+                        or inspect.isclass(attr_value)
+                        or isinstance(attr_value, staticmethod)):
                         continue
 
                     try:


### PR DESCRIPTION
Earlier staticmethod was not callable and hence decoration was skipped. Now with Python 3.10 they are callable but detect the staticmethod behavior better so that they represent the behavior before Python 3.10.

Fixes #396 