### PR TITLE
switch to get_running_loop as get_event_loop is deprecated in python 3.10

### DIFF
--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -14,7 +14,7 @@ def test_time_freeze_coroutine():
     async def frozen_coroutine():
         assert datetime.date.today() == datetime.date(1970, 1, 1)
 
-    asyncio.get_event_loop().run_until_complete(frozen_coroutine())
+    asyncio.get_running_loop().run_until_complete(frozen_coroutine())
 
 
 def test_time_freeze_async_def():
@@ -27,5 +27,5 @@ def test_time_freeze_async_def():
         @freeze_time('1970-01-01')
         async def frozen_coroutine():
             assert datetime.date.today() == datetime.date(1970, 1, 1)
-        asyncio.get_event_loop().run_until_complete(frozen_coroutine())
+        asyncio.get_running_loop().run_until_complete(frozen_coroutine())
         '''))


### PR DESCRIPTION
Fixes #398 