### PR TITLE
Removing redundant module from `sys.modules` once the test is executed

### DIFF
--- a/tests/test_class_import.py
+++ b/tests/test_class_import.py
@@ -178,7 +178,7 @@ def test_import_after_start():
     assert another_module.get_fake_localtime() is fake_localtime
     assert another_module.get_fake_gmtime() is fake_gmtime
     assert another_module.get_fake_strftime() is fake_strftime
-
+    del sys.modules['tests.another_module']
 
 def test_none_as_initial():
     with freeze_time() as ft:


### PR DESCRIPTION
This PR aims to improve test reliability of test `test_import_after_start` by cleaning the imported module `tests.another_module` by calling method `del`

The test can fail in this way if `tests.another_module` is not cleaned after the test gets executed:
```
        with freeze_time('2012-01-14'):
>           assert 'tests.another_module' not in sys.modules.keys()
E           AssertionError: assert 'tests.another_module' not in dict_keys(['sys', 'builtins', '_frozen_importlib', '_imp', '_warnings', '_io', 'marshal', 'posix', '_frozen_importlib_...nection', 'multiprocessing.queues', 'concurrent.futures.process', 'concurrent.futures.thread', 'tests.another_module'])
E            +  where dict_keys(['sys', 'builtins', '_frozen_importlib', '_imp', '_warnings', '_io', 'marshal', 'posix', '_frozen_importlib_...nection', 'multiprocessing.queues', 'concurrent.futures.process', 'concurrent.futures.thread', 'tests.another_module']) = <built-in method keys of dict object at 0x7fe667f5dd00>()
E            +    where <built-in method keys of dict object at 0x7fe667f5dd00> = {'__future__': <module '__future__' from '/usr/lib/python3.8/__future__.py'>, '__main__': <module '__main__' from '/sn...ycharm-community/248/plugins/python-ce/helpers/pycharm/_jb_pytest_runner.py'>, '_abc': <module '_abc' (built-in)>, ...}.keys
E            +      where {'__future__': <module '__future__' from '/usr/lib/python3.8/__future__.py'>, '__main__': <module '__main__' from '/sn...ycharm-community/248/plugins/python-ce/helpers/pycharm/_jb_pytest_runner.py'>, '_abc': <module '_abc' (built-in)>, ...} = sys.modules
