### PR TITLE
Remove use of unmaintained nose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,6 @@ test:
 travis:
 	pytest --cov
 
-tdaemon:
-	tdaemon -t nose ./tests/ --custom-args="--with-growl"
-
 tag:
 	python create_tag.py
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,0 @@
-[nosetests]
-verbosity=1
-detailed-errors=1
-with-coverage=1
-cover-package=freezegun

--- a/tests/test_datetimes.py
+++ b/tests/test_datetimes.py
@@ -724,7 +724,7 @@ def test_should_use_real_time():
         assert calendar.timegm(time.gmtime()) == expected_frozen
         assert calendar.timegm(time_tuple) == timestamp_to_convert
 
-    with freeze_time(frozen, ignore=['_pytest', 'nose']):
+    with freeze_time(frozen, ignore=['_pytest']):
         assert time.time() != expected_frozen
         # assert time.localtime() != expected_frozen_local
         assert time.gmtime() != expected_frozen_gmt


### PR DESCRIPTION
The nose project has ceased development. The last commit is from Mar 3,
2016. From their docs page:

https://nose.readthedocs.io/

> Note to Users
>
> Nose has been in maintenance mode for the past several years and will
> likely cease without a new person/team to take over maintainership.
> New projects should consider using Nose2, py.test, or just plain
> unittest/unittest2.

Simplify tests by using the stdlib unittest. One fewer dependency.