### PR TITLE
Remove support for end-of-life Python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - 3.5
   - 3.6
   - 3.7
   - 3.8

--- a/freezegun/api.py
+++ b/freezegun/api.py
@@ -117,7 +117,7 @@ def _get_module_attributes_hash(module):
         module_dir = dir(module)
     except (ImportError, TypeError):
         module_dir = []
-    return '{}-{}'.format(id(module), hash(frozenset(module_dir)))
+    return f'{id(module)}-{hash(frozenset(module_dir))}'
 
 
 def _get_cached_module_attributes(module):

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,6 @@ license = Apache 2.0
 classifiers =
     License :: OSI Approved :: Apache Software License
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
@@ -19,7 +18,7 @@ classifiers =
 
 [options]
 packages = freezegun
-python_requires = >=3.5
+python_requires = >=3.6
 install_requires =
     python-dateutil >= 2.7
 include_package_data = true

--- a/tests/test_warnings.py
+++ b/tests/test_warnings.py
@@ -33,7 +33,7 @@ class ModuleWithWarning:
     def attribute_that_emits_a_warning(self):
         # Use unique warning messages to avoid messages being only reported once
         self.__class__.counter += 1
-        warnings.warn('this is test warning #{counter}'.format(counter=self.__class__.counter))
+        warnings.warn(f'this is test warning #{self.__class__.counter}')
         self.warning_triggered = True
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py35, py36, py37, py38, pypy3, py{38}-mypy
+envlist = py36, py37, py38, pypy3, py{38}-mypy
 
 [testenv]
 commands = pytest --cov {posargs}


### PR DESCRIPTION
Python 3.5 is end of life. It is no longer receiving bug fixes,
including for security issues. It went EOL on 2020-09-30.

Removing older Pythons allows the project to adopt new features such as
f-strings and improved inline type annotations.