### PR TITLE
Fix typo in setup.cfg: matadata → metadata

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SHELL := /bin/bash
 
 init:
-	python setup.py develop
+	python -m pip install -e develop
 	pip install -r requirements.txt
 
 test:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
-[matadata]
+[metadata]
 name = freezegun
 version = attr: freezegun.__version__
 description = Let your Python tests travel through time

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,0 @@
-#!/usr/bin/env python
-from setuptools import setup
-
-setup()

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
+isolated_build = true
 envlist = py36, py37, py38, py39, pypy3, mypy
 
 [testenv]


### PR DESCRIPTION
Fixing to the typo exposed an issue building the wheel when using
setup.py on a system without dateutil installed. To avoid the issue,
move to a fully PEP517 compliant build approach.
