### PR TITLE
tests: asyncio: Fix Python 3.10 compatibility

### DIFF
--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -14,7 +14,7 @@ def test_time_freeze_coroutine():
     async def frozen_coroutine():
         assert datetime.date.today() == datetime.date(1970, 1, 1)
 
-    asyncio.get_event_loop().run_until_complete(frozen_coroutine())
+    asyncio.new_event_loop().run_until_complete(frozen_coroutine())
 
 
 def test_time_freeze_async_def():
@@ -27,5 +27,5 @@ def test_time_freeze_async_def():
         @freeze_time('1970-01-01')
         async def frozen_coroutine():
             assert datetime.date.today() == datetime.date(1970, 1, 1)
-        asyncio.get_event_loop().run_until_complete(frozen_coroutine())
+        asyncio.new_event_loop().run_until_complete(frozen_coroutine())
         '''))


### PR DESCRIPTION
Since Python 3.10, the `asyncio.get_event_loop()` has been deprecated in favor of `asyncio.get_running_loop()`. That one, however, issues a warning when there's no event loop running (such as in this test suite).

Fix this by always requesting a new event loop. These methods have been available since at least Python 3.5 (and there are no older docs online at this point).

Bug: https://github.com/spulec/freezegun/issues/398