### PR TITLE
Mock Pandas Timestamp now/utcnow/today methods

### DIFF
--- a/freezegun/api.py
+++ b/freezegun/api.py
@@ -81,6 +81,15 @@ try:
 except (AttributeError, ImportError):
     real_uuid_create = None
 
+try:
+    import pandas as pd
+    _PANDAS_PRESENT = True
+    real_pandas_now = pd.Timestamp.now
+    real_pandas_utcnow = pd.Timestamp.utcnow
+    real_pandas_today = pd.Timestamp.today
+except ImportError:
+    _PANDAS_PRESENT = False
+    real_pandas_now = None
 
 # keep a cache of module attributes otherwise freezegun will need to analyze too many modules all the time
 _GLOBAL_MODULES_CACHE = {}
@@ -645,6 +654,10 @@ class _freeze_time:
         time.strftime = fake_strftime
         if uuid_generate_time_attr:
             setattr(uuid, uuid_generate_time_attr, None)
+        if _PANDAS_PRESENT:
+            pd.Timestamp.now = FakeDatetime.now
+            pd.Timestamp.utcnow = FakeDatetime.utcnow
+            pd.Timestamp.today = FakeDatetime.today
         uuid._UuidCreate = None
         uuid._last_timestamp = None
 
@@ -771,6 +784,11 @@ class _freeze_time:
                 setattr(uuid, uuid_generate_time_attr, real_uuid_generate_time)
             uuid._UuidCreate = real_uuid_create
             uuid._last_timestamp = None
+
+            if _PANDAS_PRESENT:
+                pd.Timestamp.now = real_pandas_now
+                pd.Timestamp.utcnow = real_pandas_utcnow
+                pd.Timestamp.today = real_pandas_today
 
     def decorate_coroutine(self, coroutine):
         return wrap_coroutine(self, coroutine)

--- a/freezegun/api.py
+++ b/freezegun/api.py
@@ -656,13 +656,13 @@ class _freeze_time:
             setattr(uuid, uuid_generate_time_attr, None)
         if _PANDAS_PRESENT:
             def _pd_timestamp_now(*args, **kwargs):
-                return pd.to_datetime(FakeDatetime.now(*args, **kwargs))
+                return pd.Timestamp(FakeDatetime.now(*args, **kwargs))
             
             def _pd_timestamp_utcnow(*args, **kwargs):
-                return pd.to_datetime(FakeDatetime.now(*args, **kwargs))
+                return pd.Timestamp(FakeDatetime.now(*args, **kwargs))
             
             def _pd_timestamp_today(*args, **kwargs):
-                return pd.to_datetime(FakeDatetime.today(*args, **kwargs))
+                return pd.Timestamp(FakeDatetime.today(*args, **kwargs))
 
             pd.Timestamp.now = _pd_timestamp_now
             pd.Timestamp.utcnow = _pd_timestamp_utcnow

--- a/freezegun/api.py
+++ b/freezegun/api.py
@@ -655,9 +655,19 @@ class _freeze_time:
         if uuid_generate_time_attr:
             setattr(uuid, uuid_generate_time_attr, None)
         if _PANDAS_PRESENT:
-            pd.Timestamp.now = FakeDatetime.now
-            pd.Timestamp.utcnow = FakeDatetime.utcnow
-            pd.Timestamp.today = FakeDatetime.today
+            def _pd_timestamp_now(*args, **kwargs):
+                return pd.to_datetime(FakeDatetime.now(*args, **kwargs))
+            
+            def _pd_timestamp_utcnow(*args, **kwargs):
+                return pd.to_datetime(FakeDatetime.now(*args, **kwargs))
+            
+            def _pd_timestamp_today(*args, **kwargs):
+                return pd.to_datetime(FakeDatetime.today(*args, **kwargs))
+
+            pd.Timestamp.now = _pd_timestamp_now
+            pd.Timestamp.utcnow = _pd_timestamp_utcnow
+            pd.Timestamp.today = _pd_timestamp_today
+
         uuid._UuidCreate = None
         uuid._last_timestamp = None
 

--- a/tests/test_datetimes.py
+++ b/tests/test_datetimes.py
@@ -77,6 +77,9 @@ def test_simple_api():
             assert pd.Timestamp.now() == datetime.datetime(2012, 1, 14)
             assert pd.Timestamp.utcnow() == datetime.datetime(2012, 1, 14)
             assert pd.Timestamp.today() == datetime.datetime(2012, 1, 14)
+            assert isinstance(pd.Timestamp.now(), pd.Timestamp)
+            assert isinstance(pd.Timestamp.utcnow(), pd.Timestamp)
+            assert isinstance(pd.Timestamp.today(), pd.Timestamp)
     finally:
         freezer.stop()
     assert time.time() != expected_timestamp


### PR DESCRIPTION
Patch to solve #298. Freeze_time patches the pandas Timestamp, now, utcnow, and today methods if pandas is available on the system (i.e. an import pandas call does not fail) and has no effect if pandas is not installed.

The mocks are generated by wrapping the equivalent calls from FakeDatetime in a Timestamp constructor, so ticking/etc. functionality from the original class should flow directly.  However, the mocked return value of Timestamp.now, Timestamp.today, and Timestamp.utcnow is currently Timestamp, but not FakeDatetime. If the latter is necessary (e.g. if it's contracted that any freezegun'd value is always a FakeDate/FakeDatetime) I can revise the PR.