### PR TITLE
Pass all arguments on recursive freeze_time calls

### DIFF
--- a/freezegun/api.py
+++ b/freezegun/api.py
@@ -809,14 +809,14 @@ def freeze_time(time_to_freeze=None, tz_offset=0, ignore=None, tick=False, as_ar
         raise SystemError('Calling freeze_time with tick=True is only compatible with CPython')
 
     if isinstance(time_to_freeze, types.FunctionType):
-        return freeze_time(time_to_freeze(), tz_offset, ignore, tick, auto_tick_seconds)
+        return freeze_time(time_to_freeze(), tz_offset, ignore, tick, as_arg, as_kwarg, auto_tick_seconds)
 
     if isinstance(time_to_freeze, types.GeneratorType):
-        return freeze_time(next(time_to_freeze), tz_offset, ignore, tick, auto_tick_seconds)
+        return freeze_time(next(time_to_freeze), tz_offset, ignore, tick, as_arg, as_kwarg, auto_tick_seconds)
 
     if MayaDT is not None and isinstance(time_to_freeze, MayaDT):
         return freeze_time(time_to_freeze.datetime(), tz_offset, ignore,
-                           tick, as_arg)
+                           tick, as_arg, as_kwarg, auto_tick_seconds)
 
     if ignore is None:
         ignore = []

--- a/tests/test_datetimes.py
+++ b/tests/test_datetimes.py
@@ -530,6 +530,11 @@ class TestUnitTestMethodDecorator(unittest.TestCase):
         self.assertEqual(datetime.date(2013, 4, 9), datetime.date.today())
         self.assertEqual(datetime.date(2013, 4, 9), kwargs.get('hello').time_to_freeze.today())
 
+    @freeze_time(lambda: datetime.date(year=2013, month=4, day=9), as_kwarg='frozen_time')
+    def test_method_decorator_works_on_unittest_kwarg_frozen_time_with_func(self, frozen_time):
+        self.assertEqual(datetime.date(2013, 4, 9), datetime.date.today())
+        self.assertEqual(datetime.date(2013, 4, 9), frozen_time.time_to_freeze.today())
+
 
 @freeze_time('2013-04-09')
 class TestUnitTestClassDecorator(unittest.TestCase):


### PR DESCRIPTION
It appears like not all arguments are not passed when calling into `freeze_time` recursively. 

For example this unittest method decorated with `freeze_time` using a function and specifying the argument `as_kwarg` will crash:
```python
@freeze_time(lambda: datetime.date(year=2013, month=4, day=9), as_kwarg='frozen_time')
def test_method_decorator_works_on_unittest_kwarg_frozen_time_with_func(self, frozen_time):
    ...
```

```
TypeError: TestUnitTestMethodDecorator.test_method_decorator_works_on_unittest_kwarg_frozen_time_with_func() missing 1 required positional argument: 'frozen_time'
```