### PR TITLE
Install python-dateutil to fix CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
         run: pip install tox
 
       - name: Run tests
-        run: tox -e mypy
+        run: pip install python-dateutil && tox -e mypy
 
   tests:
     name: Python ${{ matrix.python-version }}
@@ -45,4 +45,4 @@ jobs:
         run: pip install tox
 
       - name: Run tests
-        run: tox -e py
+        run: pip install python-dateutil && tox -e py


### PR DESCRIPTION
CI is failing now, because:

- tox creates a source distribution and uses `setup.cfg` for it
- `setup.cfg` has a dependency on `freezegun.__version__`
- `freezegun` module imports `freezegun.api` automatically
- `freezegun.api` imports `dateutil` package
- `python-dateutil` is not installed into the python distribution that runs tox

Essentially, this dependency chain creates an unnecessary "build dependency" on `python-dateutil`. There are a few ways to break this build dependency. This PR goes the simpler way of actually installing the build dependency in CI.