### PR TITLE
build(project_urls): Add project URLs for PyPI

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -6,6 +6,11 @@ long_description = file: README.rst
 author = Steve Pulec
 author_email = spulec@gmail.com
 url = https://github.com/spulec/freezegun
+project_urls =
+    Bug Tracker = https://github.com/spulec/freezegun/issues
+    Changes = https://github.com/spulec/freezegun/blob/master/CHANGELOG
+    Documentation = https://github.com/spulec/freezegun/blob/master/README.rst
+    Source Code = https://github.com/spulec/freezegun
 license = Apache 2.0
 classifiers =
     License :: OSI Approved :: Apache Software License


### PR DESCRIPTION
Adds [`project_urls`](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls) to _setup.cfg_

This makes it easier to open via [freezegun's PyPI Page](https://pypi.org/project/freezegun/). Also valuable downstream to anyone parsing the file for any reason, e.g. downstream package maintainers

<details>

<summary>Preview</summary>

![image](https://user-images.githubusercontent.com/26336/179052046-0f85224f-d4d8-49ab-b344-8a70658dd9ad.png)

</details>