### PR TITLE
Handle rest_framework.throttling.SimpleRateThrottle 

### DIFF
--- a/freezegun/api.py
+++ b/freezegun/api.py
@@ -170,7 +170,7 @@ def get_current_time():
     return freeze_factories[-1]()
 
 
-def fake_time():
+def fake_time(*args, **kwargs):
     if _should_use_real_time():
         return real_time()
     current_time = get_current_time()

--- a/tests/fake_module_lazy.py
+++ b/tests/fake_module_lazy.py
@@ -1,0 +1,19 @@
+"""
+Lazy module aims to reproduce the context of late loaded modules
+Eg. testing a django view using the test client
+"""
+
+def load():
+    import time
+
+    class TimeAsClassAttribute:
+        """
+        Reproduce the behaviour of: rest_framework.throttling.SimpleRateThrottle
+        see: https://github.com/encode/django-rest-framework/blob/3.13.1/rest_framework/throttling.py#L63
+        """
+        _time = time.time
+
+        def call_time(self):
+            return self._time()
+
+    globals()["TimeAsClassAttribute"] = TimeAsClassAttribute

--- a/tests/test_class_import.py
+++ b/tests/test_class_import.py
@@ -134,12 +134,15 @@ def test_fake_strftime_function():
     assert fake_strftime_function() == '2012'
 
 
-@freeze_time("2022-01-01 12:00:00")
+@freeze_time("2022-01-01")
 def test_fake_time_function_as_class_attribute():
+    local_time = datetime.datetime(2022, 1, 1)
+    utc_time = local_time - datetime.timedelta(seconds=time.timezone)
+    expected_timestamp = time.mktime(utc_time.timetuple())
+
     fake_module_lazy.load()
 
-    with pytest.raises(TypeError, match='fake_time\(\) takes 0 positional arguments but 1 was given'):
-        assert fake_module_lazy.TimeAsClassAttribute().call_time()
+    assert fake_module_lazy.TimeAsClassAttribute().call_time() == expected_timestamp
 
 
 def test_import_after_start():

--- a/tests/test_class_import.py
+++ b/tests/test_class_import.py
@@ -1,5 +1,8 @@
 import time
 import sys
+
+import pytest
+
 from .fake_module import (
     fake_date_function,
     fake_datetime_function,
@@ -9,6 +12,7 @@ from .fake_module import (
     fake_time_function,
 )
 from . import fake_module
+from . import fake_module_lazy
 from freezegun import freeze_time
 from freezegun.api import (
     FakeDatetime,
@@ -128,6 +132,14 @@ def test_fake_gmtime_function():
 @freeze_time("2012-01-14")
 def test_fake_strftime_function():
     assert fake_strftime_function() == '2012'
+
+
+@freeze_time("2022-01-01 12:00:00")
+def test_fake_time_function_as_class_attribute():
+    fake_module_lazy.load()
+
+    with pytest.raises(TypeError, match='fake_time\(\) takes 0 positional arguments but 1 was given'):
+        assert fake_module_lazy.TimeAsClassAttribute().call_time()
 
 
 def test_import_after_start():

--- a/tests/test_class_import.py
+++ b/tests/test_class_import.py
@@ -37,10 +37,7 @@ def test_import_date_works():
 
 @freeze_time("2012-01-14")
 def test_import_time():
-    local_time = datetime.datetime(2012, 1, 14)
-    utc_time = local_time - datetime.timedelta(seconds=time.timezone)
-    expected_timestamp = time.mktime(utc_time.timetuple())
-    assert fake_time_function() == expected_timestamp
+    assert fake_time_function() == _date_to_time(2012, 1, 14)
 
 
 def test_start_and_stop_works():
@@ -136,13 +133,10 @@ def test_fake_strftime_function():
 
 @freeze_time("2022-01-01")
 def test_fake_time_function_as_class_attribute():
-    local_time = datetime.datetime(2022, 1, 1)
-    utc_time = local_time - datetime.timedelta(seconds=time.timezone)
-    expected_timestamp = time.mktime(utc_time.timetuple())
 
     fake_module_lazy.load()
 
-    assert fake_module_lazy.TimeAsClassAttribute().call_time() == expected_timestamp
+    assert fake_module_lazy.TimeAsClassAttribute().call_time() == _date_to_time(2022, 1, 1)
 
 
 def test_import_after_start():
@@ -199,3 +193,9 @@ def test_none_as_initial():
     with freeze_time() as ft:
         ft.move_to('2012-01-14')
         assert fake_strftime_function() == '2012'
+
+
+def _date_to_time(year, month, day):
+    local_time = datetime.datetime(year, month, day)
+    utc_time = local_time - datetime.timedelta(seconds=time.timezone)
+    return time.mktime(utc_time.timetuple())


### PR DESCRIPTION
# Handle rest_framework.throttling.SimpleRateThrottle 

According to the issue: https://github.com/spulec/freezegun/issues/382.

I can confirm that the issue comes from an incompatibility with the DRF throttling view (see: [DRF code](https://github.com/encode/django-rest-framework/blob/3.13.1/rest_framework/throttling.py#L63)).

Once the `SimpleRateThrottle.timer` is patched with `fake_time`, executing `self.timer()` (equivalent to `timer(self)`) is working with `time.time` but not with `fake_time`:

## How to reproduce

```python
>>> import time
>>> class A:
...     timer = time.time
...     def test(self):
...             print(self.timer())
... 
>>> A().test()
1658255082.1697752
>>>
>>> from freezegun.api import fake_time
>>> class B:
...     timer = fake_time
...     def test(self):
...             print(self.timer())
... 
>>> B().test()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "<stdin>", line 4, in test
TypeError: fake_time() takes 0 positional arguments but 1 was given
``` 

## About the fix

It was not that simple. Testing an API using the [test client](https://docs.djangoproject.com/en/4.0/topics/testing/tools/#the-test-client) will load the module after the patch that is performed by Freezgun. To reproduce the context of late loading I introduce the  `tests.fake_module_lazy` module (In order to add a test demonstrating the error).

Then, to fix the error I changed the signature of the `freezegun.api.fake_time` function, to accept any args/kwars (and so allow the `self.timer` usage at the origin of the issue).

I feel the change is not risky at all but I can miss something.