### PR TITLE
Don't freeze pytest timings

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,7 +30,7 @@ Decorator
     def test():
         assert datetime.datetime.now() == datetime.datetime(2012, 1, 14)
 
-    # Or a unittest TestCase - freezes for every test, from the start of setUpClass to the end of tearDownClass
+    # Or a unittest TestCase - freezes for every test, and set up and tear down code
 
     @freeze_time("1955-11-12")
     class MyTests(unittest.TestCase):

--- a/freezegun/api.py
+++ b/freezegun/api.py
@@ -593,14 +593,14 @@ class _freeze_time:
             orig_setUp = klass.setUp
             orig_tearDown = klass.tearDown
 
-            def setUp(true_self):
+            def setUp(*args, **kwargs):
                 self.start()
                 if orig_setUp is not None:
-                    orig_setUp(true_self)
+                    orig_setUp(*args, **kwargs)
 
-            def tearDown(true_self):
+            def tearDown(*args, **kwargs):
                 if orig_tearDown is not None:
-                    orig_tearDown(true_self)
+                    orig_tearDown(*args, **kwargs)
                 self.stop()
 
             klass.setUp = setUp


### PR DESCRIPTION
This avoids class-level decorator usage messing with pytest timings.

This fixes #433.