### PR TITLE
Fix freezegun.configure is not present in stub

### DIFF
--- a/freezegun/__init__.pyi
+++ b/freezegun/__init__.pyi
@@ -1,2 +1,2 @@
 from .api import freeze_time as freeze_time
-
+from .config import configure as configure


### PR DESCRIPTION
Fix for #469

Mypy returns `error: Module has no attribute "configure"` when checking such line of code
```python
freezegun.configure(extend_ignore_list=["some_lib"])
```
