### PR TITLE
Adding `prompt_toolkit` to DEFAULT_IGNORE_LIST

### DIFF
--- a/freezegun/config.py
+++ b/freezegun/config.py
@@ -12,6 +12,7 @@ DEFAULT_IGNORE_LIST = [
     '_pytest.terminal.',
     '_pytest.runner.',
     'gi',
+    'prompt_toolkit',
 ]
 
 

--- a/tests/test_configure.py
+++ b/tests/test_configure.py
@@ -51,6 +51,7 @@ def test_extend_default_ignore_list():
             '_pytest.terminal.',
             '_pytest.runner.',
             'gi',
+            'prompt_toolkit',
             'tensorflow',
         ]
 


### PR DESCRIPTION
Ignoring this library will allow IPython and ipdb's prompts to behave normally even when time is frozen.
This solves for issue https://github.com/spulec/freezegun/issues/450 as well as [this SO question](https://stackoverflow.com/questions/71584885/ipdb-stops-showing-prompt-text-after-carriage-return).

In the meantime, this problem can also be solved by adding the following configuration:
```
freezegun.configure(extend_ignore_list=['prompt_toolkit'])
```