### PR TITLE
Update gh actions 11 2022

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,9 +27,9 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - 3.7
-          - 3.8
-          - 3.9
+          - '3.7'
+          - '3.8'
+          - '3.9'
         implementation:
           - ''      # CPython
           - 'pypy'  # PyPy

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@master
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
 
       - name: Install tox
         run: pip install tox
@@ -22,7 +22,7 @@ jobs:
         run: pip install python-dateutil && tox -e mypy
 
   tests:
-    name: Python ${{ matrix.python-version }}
+    name: Python ${{ matrix.implementation }}${{ matrix.python-version }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -30,15 +30,17 @@ jobs:
           - 3.7
           - 3.8
           - 3.9
-          - pypy3
+        implementation:
+          - ''      # CPython
+          - 'pypy'  # PyPy
 
     steps:
       - uses: actions/checkout@master
 
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+      - name: Set up Python ${{ matrix.implementation }}${{ matrix.python-version }}
+        uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: ${{ matrix.implementation }}${{ matrix.python-version }}
 
       - name: Install tox
         run: pip install tox

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py36, py37, py38, py39, pypy3, mypy
+envlist = py37, py38, py39, pypy3, mypy
 
 [testenv]
 commands = pytest --cov {posargs}


### PR DESCRIPTION
### Objectives
1. Make `tox` run locally
    - remove py3.6 from tox envs
2. Make GitHub Actions run on all compatible PyPy versions
    - update setup to v4 (to support PyPy's new version annotation, e.g. `pypy3.x`)
    - added implementation type (`CPython`/`PyPy`)
    - changed versions from floats to strings (otherwise `3.10` would be interpreted as `3.1`)