### PR TITLE
Fix gh actions and mp utest

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@master
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
 
       - name: Install tox
         run: pip install tox
@@ -22,23 +22,25 @@ jobs:
         run: pip install python-dateutil && tox -e mypy
 
   tests:
-    name: Python ${{ matrix.python-version }}
+    name: Python ${{ matrix.implementation }}${{ matrix.python-version }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version:
-          - 3.7
-          - 3.8
-          - 3.9
-          - pypy3
+          - '3.7'
+          - '3.8'
+          - '3.9'
+        implementation:
+          - ''      # CPython
+          - 'pypy'  # PyPy
 
     steps:
       - uses: actions/checkout@master
 
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+      - name: Set up Python ${{ matrix.implementation }}${{ matrix.python-version }}
+        uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: ${{ matrix.implementation }}${{ matrix.python-version }}
 
       - name: Install tox
         run: pip install tox

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ classifiers =
 
 [options]
 packages = freezegun
-python_requires = >=3.6
+python_requires = >=3.7
 install_requires =
     python-dateutil >= 2.7
 include_package_data = true

--- a/tests/test_configure.py
+++ b/tests/test_configure.py
@@ -46,6 +46,7 @@ def test_extend_default_ignore_list():
             'django.utils.six.moves',
             'google.gax',
             'threading',
+            'multiprocessing',
             'Queue',
             'selenium',
             '_pytest.terminal.',

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py36, py37, py38, py39, pypy3, mypy
+envlist = py37, py38, py39, pypy3, mypy
 
 [testenv]
 commands = pytest --cov {posargs}


### PR DESCRIPTION
This PR includes three updates (in two distinct merges);
1. Drop python 3.6 (GitHub Actions no longer supports this version, so the tests just fail, blocking further executions).
1. Make GitHub Actions test against multiple pypy versions, so the testing matrix is more accurate and provides coverage across multiple pypy versions.
This includes changing the version identifiers from floats to strings (making `"3.1" != "3.10"`).
1. Fix a unittest to expect the `multiprocessing` module to be ignored - following the merge of #489. This fixes the following error in unittest `test_configure.py:test_extend_default_ignore_list()`:
```
E           AssertionError: expected call not found.
E           Expected: __init__(time_to_freeze_str='2020-10-06', tz_offset=0, ignore=['nose.plugins', 'six.moves', 'django.utils.six.moves', 'google.gax', 'threading', 'Queue', 'selenium', '_pytest.terminal.', '_pytest.runner.', 'gi', 'prompt_toolkit', 'tensorflow'], tick=False, as_arg=False, as_kwarg='', auto_tick_seconds=0)
E           Actual: __init__(time_to_freeze_str='2020-10-06', tz_offset=0, ignore=['nose.plugins', 'six.moves', 'django.utils.six.moves', 'google.gax', 'threading', 'multiprocessing', 'Queue', 'selenium', '_pytest.terminal.', '_pytest.runner.', 'gi', 'prompt_toolkit', 'tensorflow'], tick=False, as_arg=False, as_kwarg='', auto_tick_seconds=0)
```


---
This PR includes PR #483, but in addition also fixes a broken unittest. If this is merged, #483 can be closed as obsolete.
The test results (GH Actions) for this PR can be reviewed and verified at [micromoses/freezegun/pull/1](https://github.com/micromoses/freezegun/pull/1).

Thanks!