### PR TITLE
Py310 311 adapt staticmethods

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,6 +30,8 @@ jobs:
           - '3.7'
           - '3.8'
           - '3.9'
+          - '3.10'
+          - '3.11'
         implementation:
           - ''      # CPython
           - 'pypy'  # PyPy

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,6 +35,11 @@ jobs:
         implementation:
           - ''      # CPython
           - 'pypy'  # PyPy
+        exclude:    # unreleased;
+          - implementation: 'pypy'
+            python-version: '3.10'
+          - implementation: 'pypy'
+            python-version: '3.11'
 
     steps:
       - uses: actions/checkout@master

--- a/freezegun/api.py
+++ b/freezegun/api.py
@@ -619,7 +619,7 @@ class _freeze_time:
                         continue
                     seen.add(attr)
 
-                    if not callable(attr_value) or inspect.isclass(attr_value):
+                    if not callable(attr_value) or inspect.isclass(attr_value) or isinstance(attr_value, staticmethod):
                         continue
 
                     try:

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,8 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py37, py38, py39, pypy3, mypy
+envlist = py37, py38, py39, py310, py311, pypy3, mypy
 
 [testenv]
 commands = pytest --cov {posargs}


### PR DESCRIPTION
Making unittests pass on python 3.10 and 3.11;
* Merged from #478 and resolved conflicts
* Excluded testing of these version on PyPy in GH Actions as they are not yet released (and therefore fail in GH)
* Fixed handling of `@staticmethod`s, as these were [changed in python3.10](https://docs.python.org/3/library/functions.html#staticmethod);
> Changed in version 3.10: Static methods now inherit the method attributes (__module__, __name__, __qualname__, __doc__ and __annotations__), have a new __wrapped__ attribute, and are now callable as regular functions.

#### Explanation:
Up to python 3.10, staticmethods were not callable - so they were skipped by the condition.  
Since python 3.10, staticmethod definitions ARE callable. While this would usually have minimal impact in most standard use-cases, it does react differently to lower-level attribute access (such as `__dict__`, which is used in this case). Explicitly testing for staticmethods makes tests pass on py>=3.10, while having no effect for versions of py<3.10 as staticmethods are not `callable()` in these versions in the first place.