### PR TITLE
Py310 fix aio warning in ut

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,6 +30,8 @@ jobs:
           - '3.7'
           - '3.8'
           - '3.9'
+          - '3.10'
+          - '3.11'
         implementation:
           - ''      # CPython
           - 'pypy'  # PyPy

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,6 +35,11 @@ jobs:
         implementation:
           - ''      # CPython
           - 'pypy'  # PyPy
+        exclude:    # unreleased;
+          - implementation: 'pypy'
+            python-version: '3.10'
+          - implementation: 'pypy'
+            python-version: '3.11'
 
     steps:
       - uses: actions/checkout@master

--- a/freezegun/api.py
+++ b/freezegun/api.py
@@ -619,7 +619,7 @@ class _freeze_time:
                         continue
                     seen.add(attr)
 
-                    if not callable(attr_value) or inspect.isclass(attr_value):
+                    if not callable(attr_value) or inspect.isclass(attr_value) or isinstance(attr_value, staticmethod):
                         continue
 
                     try:

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,8 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
 

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -14,4 +14,4 @@ def test_time_freeze_coroutine():
     async def frozen_coroutine():
         assert datetime.date.today() == datetime.date(1970, 1, 1)
 
-    asyncio.new_event_loop().run_until_complete(frozen_coroutine())
+    asyncio.run(frozen_coroutine())

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -14,7 +14,7 @@ def test_time_freeze_coroutine():
     async def frozen_coroutine():
         assert datetime.date.today() == datetime.date(1970, 1, 1)
 
-    asyncio.get_event_loop().run_until_complete(frozen_coroutine())
+    asyncio.new_event_loop().run_until_complete(frozen_coroutine())
 
 
 def test_time_freeze_async_def():
@@ -27,5 +27,5 @@ def test_time_freeze_async_def():
         @freeze_time('1970-01-01')
         async def frozen_coroutine():
             assert datetime.date.today() == datetime.date(1970, 1, 1)
-        asyncio.get_event_loop().run_until_complete(frozen_coroutine())
+        asyncio.new_event_loop().run_until_complete(frozen_coroutine())
         '''))

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -15,17 +15,3 @@ def test_time_freeze_coroutine():
         assert datetime.date.today() == datetime.date(1970, 1, 1)
 
     asyncio.new_event_loop().run_until_complete(frozen_coroutine())
-
-
-def test_time_freeze_async_def():
-    try:
-        exec('async def foo(): pass')
-    except SyntaxError:
-        raise SkipTest('async def not supported')
-    else:
-        exec(dedent('''
-        @freeze_time('1970-01-01')
-        async def frozen_coroutine():
-            assert datetime.date.today() == datetime.date(1970, 1, 1)
-        asyncio.new_event_loop().run_until_complete(frozen_coroutine())
-        '''))

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py37, py38, py39, pypy3, mypy
+envlist = py37, py38, py39, py310, py311, pypy3, mypy
 
 [testenv]
 commands = pytest --cov {posargs}


### PR DESCRIPTION
Fixing for `tests/test_asyncio.py:17: DeprecationWarning: There is no current event loop`.  
Based on #492 , merged from #421 , and including suggested changes by @graingert 

cherry against 492:
```
+ 6199e24c7145856f15c4d5b69c442bb6a522bd0a tests: asyncio: Fix Python 3.10 compatibility
+ 204647b305b3baab9d3f0be96afce7f6e3d4a25f Removed test as per @graingert's comment
+ c7926bda7315d22252bbbca2ca393bf37c078cc8 Changed asyncio to `run()` as per @graingert's suggestion
```