### PR TITLE
Update version to latest in CHANGELOG (1.3.0)

### DIFF
--- a/freezegun/__init__.py
+++ b/freezegun/__init__.py
@@ -9,7 +9,7 @@ from .api import freeze_time
 from .config import configure
 
 __title__ = 'freezegun'
-__version__ = '1.2.2'
+__version__ = '1.3.0'
 __author__ = 'Steve Pulec'
 __license__ = 'Apache License 2.0'
 __copyright__ = 'Copyright 2012 Steve Pulec'


### PR DESCRIPTION
This version is the latest in the CHANGELOG after #470 was merged. I think updating this makes `git+https` pip installs work better because the version doesn't clash: https://github.com/pypa/pip/issues/5780#issuecomment-678676463