### PR TITLE
better represent the return value of freeze_time at typing time

### DIFF
--- a/freezegun/api.pyi
+++ b/freezegun/api.pyi
@@ -1,11 +1,12 @@
 from collections.abc import Awaitable, Callable, Iterator, Sequence
 from datetime import date, datetime, timedelta
 from numbers import Real
-from typing import Any, TypeVar, overload
+from typing import Generic, Literal, TypeVar, overload
 from typing_extensions import TypeAlias
 
 _T = TypeVar("_T")
 _Freezable: TypeAlias = str | datetime | date | timedelta
+_Factory = TypeVar("_Factory", bound=TickingDateTimeFactory | FrozenDateTimeFactory | StepTickTimeFactory)
 
 class TickingDateTimeFactory:
     def __init__(self, time_to_freeze: datetime, start: datetime) -> None: ...
@@ -24,7 +25,7 @@ class StepTickTimeFactory:
     def update_step_width(self, step_width: float) -> None: ...
     def move_to(self, target_datetime: _Freezable | None) -> None: ...
 
-class _freeze_time:
+class _freeze_time(Generic[_Factory]):
     def __init__(
         self,
         time_to_freeze_str: _Freezable | None,
@@ -41,20 +42,45 @@ class _freeze_time:
     def __call__(self, func: Callable[..., Awaitable[_T]]) -> Callable[..., Awaitable[_T]]: ...
     @overload
     def __call__(self, func: Callable[..., _T]) -> Callable[..., _T]: ...
-    def __enter__(self) -> FrozenDateTimeFactory | StepTickTimeFactory: ...
+    def __enter__(self) -> _Factory: ...
     def __exit__(self, *args: object) -> None: ...
-    def start(self) -> Any: ...
+    def start(self) -> _Factory: ...
     def stop(self) -> None: ...
     def decorate_class(self, klass: type[_T]) -> _T: ...
     def decorate_coroutine(self, coroutine: _T) -> _T: ...
     def decorate_callable(self, func: Callable[..., _T]) -> Callable[..., _T]: ...
 
+@overload
 def freeze_time(
     time_to_freeze: _Freezable | Callable[..., _Freezable] | Iterator[_Freezable] | None = ...,
     tz_offset: int | timedelta | None = ...,
     ignore: Sequence[str] | None = ...,
-    tick: bool | None = ...,
-    as_arg: bool | None = ...,
-    as_kwarg: str | None = ...,
-    auto_tick_seconds: float | None = ...,
-) -> _freeze_time: ...
+    tick: bool = ...,
+    as_arg: bool = ...,
+    as_kwarg: str = ...,
+    *,
+    auto_tick_seconds: float,
+) -> _freeze_time[StepTickTimeFactory]: ...
+
+@overload
+def freeze_time(
+    time_to_freeze: _Freezable | Callable[..., _Freezable] | Iterator[_Freezable] | None = ...,
+    tz_offset: int | timedelta | None = ...,
+    ignore: Sequence[str] | None = ...,
+    as_arg: bool = ...,
+    as_kwarg: str = ...,
+    auto_tick_seconds: None = ...,
+    *,
+    tick: Literal[True],
+) -> _freeze_time[TickingDateTimeFactory]: ...
+
+@overload
+def freeze_time(
+    time_to_freeze: _Freezable | Callable[..., _Freezable] | Iterator[_Freezable] | None = ...,
+    tz_offset: int | timedelta | None = ...,
+    ignore: Sequence[str] | None = ...,
+    tick: bool = ...,
+    as_arg: bool = ...,
+    as_kwarg: str = ...,
+    auto_tick_seconds: None = ...,
+) -> _freeze_time[FrozenDateTimeFactory]: ...


### PR DESCRIPTION
currently to use any of the freezegun methods with a `freeze_time` context you need to assert `isinstance` after getting the return value

this change makes it so the yield types are correctly inferred:

```python
import freezegun

with freezegun.freeze_time('2023-01-01 00:00:00') as t1:
    print(t1)  # <freezegun.api.FrozenDateTimeFactory object at 0x7ffbe315e4a0>
    reveal_type(t1)  # note: Revealed type is "freezegun.api.FrozenDateTimeFactory"

with freezegun.freeze_time('2023-01-01 00:00:00', tick=True) as t2:
    print(t2)  # <freezegun.api.TickingDateTimeFactory object at 0x7ffbe308c6a0>
    reveal_type(t2)  # note: Revealed type is "freezegun.api.TickingDateTimeFactory"

with freezegun.freeze_time('2023-01-01 00:00:00', auto_tick_seconds=3) as t3:
    print(t3)  # <freezegun.api.StepTickTimeFactory object at 0x7ffbe25fa020>
    reveal_type(t3)  # note: Revealed type is "freezegun.api.StepTickTimeFactory"
```