### PR TITLE
Use formatted integers

### DIFF
--- a/freezegun/api.py
+++ b/freezegun/api.py
@@ -175,13 +175,13 @@ def fake_time():
     if _should_use_real_time():
         return real_time()
     current_time = get_current_time()
-    return calendar.timegm(current_time.timetuple()) + current_time.microsecond / 1000000.0
+    return calendar.timegm(current_time.timetuple()) + current_time.microsecond / 1_000_000
 
 if _TIME_NS_PRESENT:
     def fake_time_ns():
         if _should_use_real_time():
             return real_time_ns()
-        return int(int(fake_time()) * 1e9)
+        return int(fake_time()) * 1_000_000_000
 
 
 def fake_localtime(t=None):
@@ -206,7 +206,7 @@ def _get_fake_monotonic():
     current_time = get_current_time()
     return (
         calendar.timegm(current_time.timetuple()) +
-        current_time.microsecond / 1e6
+        current_time.microsecond / 1_000_000
     )
 
 
@@ -214,7 +214,7 @@ def _get_fake_monotonic_ns():
     # For monotonic timers like .monotonic(), .perf_counter(), etc
     current_time = get_current_time()
     return (
-        calendar.timegm(current_time.timetuple()) * 1000000 +
+        calendar.timegm(current_time.timetuple()) * 1_000_000 +
         current_time.microsecond
     ) * 1000
 

--- a/tests/test_datetimes.py
+++ b/tests/test_datetimes.py
@@ -208,10 +208,10 @@ def test_bad_time_argument():
 
 
 @pytest.mark.parametrize("func_name, has_func, tick_size", (
-    ("monotonic", True, 1.0),
-    ("monotonic_ns", HAS_MONOTONIC_NS, int(1e9)),
-    ("perf_counter", True, 1.0),
-    ("perf_counter_ns", HAS_PERF_COUNTER_NS, int(1e9)),)
+    ("monotonic", True, 1),
+    ("monotonic_ns", HAS_MONOTONIC_NS, 1_000_000_000),
+    ("perf_counter", True, 1),
+    ("perf_counter_ns", HAS_PERF_COUNTER_NS, 1_000_000_000),)
 )
 def test_time_monotonic(func_name, has_func, tick_size):
     initial_datetime = datetime.datetime(year=1, month=7, day=12,
@@ -724,7 +724,7 @@ def test_should_use_real_time():
         if HAS_CLOCK:
             assert time.clock() == expected_clock
         if HAS_TIME_NS:
-            assert time.time_ns() == expected_frozen * 1e9
+            assert time.time_ns() == expected_frozen * 1_000_000_000
 
         assert calendar.timegm(time.gmtime()) == expected_frozen
         assert calendar.timegm(time_tuple) == timestamp_to_convert
@@ -736,7 +736,7 @@ def test_should_use_real_time():
         if HAS_CLOCK:
             assert time.clock() != expected_clock
         if HAS_TIME_NS:
-            assert time.time_ns() != expected_frozen * 1e9
+            assert time.time_ns() != expected_frozen * 1_000_000_000
 
         assert calendar.timegm(time.gmtime()) != expected_frozen
         assert calendar.timegm(time_tuple) == timestamp_to_convert
@@ -752,10 +752,10 @@ def test_time_ns():
 
     freezer.start()
     assert time.time() == expected_timestamp
-    assert time.time_ns() == expected_timestamp * 1e9
+    assert time.time_ns() == expected_timestamp * 1_000_000_000
     freezer.stop()
     assert time.time() != expected_timestamp
-    assert time.time_ns() != expected_timestamp * 1e9
+    assert time.time_ns() != expected_timestamp * 1_000_000_000
 
 
 def test_compare_datetime_and_time_with_timezone(monkeypatch):


### PR DESCRIPTION
`1e9` is a float. `1_000_000_000` is an integer representing e.g. number of nanoseconds in a second. For up to 9 zeroes, formatting them as `1_000_000_000` looks good in code.  Another possibility would be `10**9`.