### PR TITLE
Switch to pytest-cov

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pytest
-pytest-coverage
+pytest-cov
 coveralls
 python-dateutil >= 2.7
 maya; python_version < '3.12'


### PR DESCRIPTION
The `pytest-coverage` projects [suggests](https://pypi.org/project/pytest-coverage/0.0/): Use [pytest-cover](https://pypi.python.org/pypi/pytest-cover/) instead.

The [pytest-cover](https://pypi.org/project/pytest-cover/) says: pytest-cover has been merged back into [pytest-cov 2.0](https://pypi.python.org/pypi/pytest-cov).

So let's use `pytest-cov`.