### PR TITLE
rename excluded package "Queue" to match its python 3 name

### DIFF
--- a/freezegun/config.py
+++ b/freezegun/config.py
@@ -8,7 +8,7 @@ DEFAULT_IGNORE_LIST = [
     'google.gax',
     'threading',
     'multiprocessing',
-    'Queue',
+    'queue',
     'selenium',
     '_pytest.terminal.',
     '_pytest.runner.',

--- a/tests/test_configure.py
+++ b/tests/test_configure.py
@@ -48,7 +48,7 @@ def test_extend_default_ignore_list():
             'google.gax',
             'threading',
             'multiprocessing',
-            'Queue',
+            'queue',
             'selenium',
             '_pytest.terminal.',
             '_pytest.runner.',


### PR DESCRIPTION
On python 3 `Queue` was renamed to `queue`. As a result it seems this is no longer excluding the queue package.