### PR TITLE
Ignore duplicate modules in ignore list

### DIFF
--- a/freezegun/config.py
+++ b/freezegun/config.py
@@ -35,7 +35,7 @@ def configure(default_ignore_list: Optional[List[str]]=None, extend_ignore_list:
     if default_ignore_list:
         settings.default_ignore_list = default_ignore_list
     if extend_ignore_list:
-        settings.default_ignore_list = [*settings.default_ignore_list, *extend_ignore_list]
+        settings.default_ignore_list = list(dict.fromkeys([*settings.default_ignore_list, *extend_ignore_list]))
 
 
 def reset_config() -> None:

--- a/tests/test_configure.py
+++ b/tests/test_configure.py
@@ -67,3 +67,40 @@ def test_extend_default_ignore_list():
             auto_tick_seconds=0,
             real_asyncio=False,
         )
+
+def test_extend_default_ignore_list_duplicate_items():
+    freezegun.configure(extend_ignore_list=['tensorflow', 'pymongo', 'tensorflow','rabbitmq'])
+    freezegun.configure(extend_ignore_list=['tensorflow'])
+
+    with mock.patch("freezegun.api._freeze_time.__init__", return_value=None) as _freeze_time_init_mock:
+
+        freezegun.freeze_time("2020-10-06")
+
+        expected_ignore_list = [
+            'nose.plugins',
+            'six.moves',
+            'django.utils.six.moves',
+            'google.gax',
+            'threading',
+            'multiprocessing',
+            'queue',
+            'selenium',
+            '_pytest.terminal.',
+            '_pytest.runner.',
+            'gi',
+            'prompt_toolkit',
+            'tensorflow',
+            'pymongo',
+            'rabbitmq',
+        ]
+
+        _freeze_time_init_mock.assert_called_once_with(
+            time_to_freeze_str="2020-10-06",
+            tz_offset=0,
+            ignore=expected_ignore_list,
+            tick=False,
+            as_arg=False,
+            as_kwarg='',
+            auto_tick_seconds=0,
+            real_asyncio=False,
+        )


### PR DESCRIPTION
Ignore duplicate modules passed in ignore_list. This could also be done with calling `set` on the final ignore list but sets are unordered which in terms of functionality I reckon should be ok but it was a pain in tests, so opted for a this `dict.fromkeys` way since supported python versions are >=3.7

fixes: #499 