### PR TITLE
Only call uuid._load_system_functions() if it exists.

### DIFF
--- a/freezegun/api.py
+++ b/freezegun/api.py
@@ -68,7 +68,9 @@ try:
     uuid_generate_time_attr = '_uuid_generate_time'
 except AttributeError:
     # noinspection PyUnresolvedReferences
-    uuid._load_system_functions()
+    if hasattr(uuid, '_load_system_functions'):
+        # A no-op after Python ~3.9, being removed in 3.13.
+        uuid._load_system_functions()
     # noinspection PyUnresolvedReferences
     real_uuid_generate_time = uuid._generate_time_safe
     uuid_generate_time_attr = '_generate_time_safe'


### PR DESCRIPTION
This private API has been a no-op for several releases and is going away in Python 3.13.