### PR TITLE
Allow `default_ignore_list` to be empty

### DIFF
--- a/freezegun/config.py
+++ b/freezegun/config.py
@@ -32,7 +32,7 @@ class ConfigurationError(Exception):
 def configure(default_ignore_list: Optional[List[str]]=None, extend_ignore_list: Optional[List[str]]=None) -> None:
     if default_ignore_list is not None and extend_ignore_list is not None:
         raise ConfigurationError("Either default_ignore_list or extend_ignore_list might be given, not both")
-    if default_ignore_list:
+    if default_ignore_list is not None:
         settings.default_ignore_list = default_ignore_list
     if extend_ignore_list:
         settings.default_ignore_list = list(dict.fromkeys([*settings.default_ignore_list, *extend_ignore_list]))

--- a/tests/test_configure.py
+++ b/tests/test_configure.py
@@ -1,4 +1,5 @@
 from unittest import mock
+import pytest
 import freezegun
 import freezegun.config
 
@@ -10,23 +11,21 @@ def setup_function():
 def teardown_function():
     freezegun.config.reset_config()
 
-
-def test_default_ignore_list_is_overridden():
-    freezegun.configure(default_ignore_list=['threading', 'tensorflow'])
+@pytest.mark.parametrize('ignorelist', (
+    ['threading', 'tensorflow'],  # example from docs
+    [],  # ignore nothing
+))
+def test_default_ignore_list_is_overridden(ignorelist):
+    freezegun.configure(default_ignore_list=list(ignorelist))
 
     with mock.patch("freezegun.api._freeze_time.__init__", return_value=None) as _freeze_time_init_mock:
 
         freezegun.freeze_time("2020-10-06")
 
-        expected_ignore_list = [
-            'threading',
-            'tensorflow',
-        ]
-
         _freeze_time_init_mock.assert_called_once_with(
             time_to_freeze_str="2020-10-06",
             tz_offset=0,
-            ignore=expected_ignore_list,
+            ignore=ignorelist,
             tick=False,
             as_arg=False,
             as_kwarg='',
@@ -34,8 +33,12 @@ def test_default_ignore_list_is_overridden():
             real_asyncio=False,
         )
 
-def test_extend_default_ignore_list():
-    freezegun.configure(extend_ignore_list=['tensorflow'])
+@pytest.mark.parametrize('ignorelist', (
+    ['tensorflow'],  # example from docs
+    [],  # ignore nothing extra
+))
+def test_extend_default_ignore_list(ignorelist):
+    freezegun.configure(extend_ignore_list=list(ignorelist))
 
     with mock.patch("freezegun.api._freeze_time.__init__", return_value=None) as _freeze_time_init_mock:
 
@@ -54,8 +57,7 @@ def test_extend_default_ignore_list():
             '_pytest.runner.',
             'gi',
             'prompt_toolkit',
-            'tensorflow',
-        ]
+        ] + ignorelist
 
         _freeze_time_init_mock.assert_called_once_with(
             time_to_freeze_str="2020-10-06",


### PR DESCRIPTION
Hello,
Thank you for freezegun!

I wanted to disable the default ignore list, but I noticed that `configure(default_ignore_list=[])` is equivalent to `default_ignore_list=None`. I believe it should instead ignore nothing.

I added a `is not None`, and a test.
I added the same test for `test_extend_default_ignore_list`, but since None and [] are equivalent there, that doesn't need code changes.