### PR TITLE
Change fromtimestamp argument name to match standard library

### DIFF
--- a/freezegun/api.py
+++ b/freezegun/api.py
@@ -384,12 +384,12 @@ class FakeDatetime(real_datetime, FakeDate, metaclass=FakeDatetimeMeta):
         return datetime_to_fakedatetime(real_datetime.astimezone(self, tz))
 
     @classmethod
-    def fromtimestamp(cls, t: float, tz: Optional[datetime.tzinfo]=None) -> "FakeDatetime":
+    def fromtimestamp(cls, timestamp: float, tz: Optional[datetime.tzinfo]=None) -> "FakeDatetime":
         if tz is None:
             tz = dateutil.tz.tzoffset("freezegun", cls._tz_offset())
-            result = real_datetime.fromtimestamp(t, tz=tz).replace(tzinfo=None)
+            result = real_datetime.fromtimestamp(timestamp, tz=tz).replace(tzinfo=None)
         else:
-            result = real_datetime.fromtimestamp(t, tz)
+            result = real_datetime.fromtimestamp(timestamp, tz)
         return datetime_to_fakedatetime(result)
 
     def timestamp(self) -> float:


### PR DESCRIPTION
I am using `datetime.datetime.fromtimestamp` with `timestamp` as a keyword argument.
However, with `freezegun` the expected argument name is `t`.

With Python 3.13 or Python 3.12 at least:

```python
import datetime
from freezegun import freeze_time

datetime.datetime.fromtimestamp(timestamp=0)

with freeze_time("2012-01-14"):
    datetime.datetime.fromtimestamp(timestamp=0)  # This errors with `TypeError: FakeDatetime.fromtimestamp() got an unexpected keyword argument 'timestamp'`
```