### PR TITLE
Tests: fixup: replace 'datetime.today' classmethod calls with 'datetime.date' method

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,12 +54,12 @@ Decorator
         @freeze_time('2013-04-09', as_kwarg='frozen_time')
         def test_method_decorator_works_on_unittest(self, frozen_time):
             self.assertEqual(datetime.date(2013, 4, 9), datetime.date.today())
-            self.assertEqual(datetime.date(2013, 4, 9), frozen_time.time_to_freeze.today())
+            self.assertEqual(datetime.date(2013, 4, 9), frozen_time.time_to_freeze.date())
 
         @freeze_time('2013-04-09', as_kwarg='hello')
         def test_method_decorator_works_on_unittest(self, **kwargs):
             self.assertEqual(datetime.date(2013, 4, 9), datetime.date.today())
-            self.assertEqual(datetime.date(2013, 4, 9), kwargs.get('hello').time_to_freeze.today())
+            self.assertEqual(datetime.date(2013, 4, 9), kwargs.get('hello').time_to_freeze.date())
 
 Context manager
 ~~~~~~~~~~~~~~~

--- a/tests/test_datetimes.py
+++ b/tests/test_datetimes.py
@@ -534,17 +534,17 @@ class TestUnitTestMethodDecorator(unittest.TestCase):
     @freeze_time('2013-04-09', as_kwarg='frozen_time')
     def test_method_decorator_works_on_unittest_kwarg_frozen_time(self, frozen_time: Any) -> None:
         self.assertEqual(datetime.date(2013, 4, 9), datetime.date.today())
-        self.assertEqual(datetime.date(2013, 4, 9), frozen_time.time_to_freeze.today())
+        self.assertEqual(datetime.date(2013, 4, 9), frozen_time.time_to_freeze.date())
 
     @freeze_time('2013-04-09', as_kwarg='hello')
     def test_method_decorator_works_on_unittest_kwarg_hello(self, **kwargs: Any) -> None:
         self.assertEqual(datetime.date(2013, 4, 9), datetime.date.today())
-        self.assertEqual(datetime.date(2013, 4, 9), kwargs.get('hello').time_to_freeze.today())  # type: ignore
+        self.assertEqual(datetime.date(2013, 4, 9), kwargs.get('hello').time_to_freeze.date())  # type: ignore
 
     @freeze_time(lambda: datetime.date(year=2013, month=4, day=9), as_kwarg='frozen_time')
     def test_method_decorator_works_on_unittest_kwarg_frozen_time_with_func(self, frozen_time: Any) -> None:
         self.assertEqual(datetime.date(2013, 4, 9), datetime.date.today())
-        self.assertEqual(datetime.date(2013, 4, 9), frozen_time.time_to_freeze.today())
+        self.assertEqual(datetime.date(2013, 4, 9), frozen_time.time_to_freeze.date())
 
 
 @freeze_time('2013-04-09')

--- a/tests/test_datetimes.py
+++ b/tests/test_datetimes.py
@@ -534,17 +534,17 @@ class TestUnitTestMethodDecorator(unittest.TestCase):
     @freeze_time('2013-04-09', as_kwarg='frozen_time')
     def test_method_decorator_works_on_unittest_kwarg_frozen_time(self, frozen_time: Any) -> None:
         self.assertEqual(datetime.date(2013, 4, 9), datetime.date.today())
-        assert frozen_time.time_to_freeze.today().strftime('%Y-%m-%d') == "2013-04-09"
+        self.assertEqual(datetime.date(2013, 4, 9), frozen_time.time_to_freeze.today())
 
     @freeze_time('2013-04-09', as_kwarg='hello')
     def test_method_decorator_works_on_unittest_kwarg_hello(self, **kwargs: Any) -> None:
         self.assertEqual(datetime.date(2013, 4, 9), datetime.date.today())
-        assert kwargs.get("hello").time_to_freeze.today().strftime('%Y-%m-%d') == "2013-04-09"  # type: ignore
+        self.assertEqual(datetime.date(2013, 4, 9), kwargs.get('hello').time_to_freeze.today())  # type: ignore
 
     @freeze_time(lambda: datetime.date(year=2013, month=4, day=9), as_kwarg='frozen_time')
     def test_method_decorator_works_on_unittest_kwarg_frozen_time_with_func(self, frozen_time: Any) -> None:
         self.assertEqual(datetime.date(2013, 4, 9), datetime.date.today())
-        assert frozen_time.time_to_freeze.today().strftime('%Y-%m-%d') == "2013-04-09"
+        self.assertEqual(datetime.date(2013, 4, 9), frozen_time.time_to_freeze.today())
 
 
 @freeze_time('2013-04-09')


### PR DESCRIPTION
This provides an alternative resolution for a Python3.13 upgrade compatibility issue, by ensuring that both sides of the comparison are `datetime.date` objects.  Previously we had been calling `datetime.today()` that would return a `datetime.datetime` instance as the r-value.

This should also allow the test suite to pass regardless of the `TZ` (timezone) configuration of the test runner/system.

Ref: #550