### PR TITLE
Mark support for Python 3.13

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
           - '3.10'
           - '3.11'
           - '3.12'
-          - '3.13.0-beta.2'
+          - '3.13'
 
     steps:
       - uses: actions/checkout@master
@@ -45,7 +45,7 @@ jobs:
           - '3.10'
           - '3.11'
           - '3.12'
-          - '3.13.0-beta.2'
+          - '3.13'
         implementation:
           - ''      # CPython
           - 'pypy'  # PyPy
@@ -55,7 +55,7 @@ jobs:
           - implementation: 'pypy'
             python-version: '3.12'
           - implementation: 'pypy'
-            python-version: '3.13.0-beta.2'
+            python-version: '3.13'
 
     steps:
       - uses: actions/checkout@master

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,12 @@
 Freezegun Changelog
 ===================
 
+1.5.2
+-----
+ * Remove support for Python 3.7
+ * Explicitly marks support for Python 3.13
+ * Improved project documentation
+
 1.5.1
 -----
  * Fix the typing of the `tick()` method, and improve it's behaviour.

--- a/freezegun/api.py
+++ b/freezegun/api.py
@@ -633,10 +633,6 @@ class _freeze_time:
         self.real_asyncio = real_asyncio
 
     @overload
-    def __call__(self, func: Type[T2]) -> Type[T2]:
-        ...
-
-    @overload
     def __call__(self, func: "Callable[P, Awaitable[Any]]") -> "Callable[P, Awaitable[Any]]":
         ...
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,15 +11,15 @@ project_urls =
     Changes = https://github.com/spulec/freezegun/blob/master/CHANGELOG
     Documentation = https://github.com/spulec/freezegun/blob/master/README.rst
     Source Code = https://github.com/spulec/freezegun
-license = Apache 2.0
+license = Apache-2.0
 classifiers =
-    License :: OSI Approved :: Apache Software License
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -32,5 +32,5 @@ def cpython_only(func: "Callable[P, T]") -> "Callable[P, T]":
     def wrapper(*args: "P.args", **kwargs: "P.kwargs") -> T:
         if not _is_cpython:
             raise SkipTest("Requires CPython")
-        return func(*args)
+        return func(*args, **kwargs)
     return wrapper


### PR DESCRIPTION
 - Document support for Python 3.13
 - Fix license format to comply with PEP 639
 - Fix typing issues in latest `mypy`
 - Prep for 1.5.2 release