### PR TITLE
@freeze_time("2012-01-14", as_arg=True) is not working

### DIFF
--- a/freezegun/api.py
+++ b/freezegun/api.py
@@ -927,7 +927,7 @@ class _freeze_time:
             assert False, "You can't specify both as_arg and as_kwarg at the same time. Pick one."
         if self.as_arg:
             result = func(time_factory, *args, **kwargs)  # type: ignore
-        if self.as_kwarg:
+        elif self.as_kwarg:
             kwargs[self.as_kwarg] = time_factory
             result = func(*args, **kwargs)
         else:

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -139,3 +139,21 @@ def test_auto_and_manual_tick(
         incremented_time = datetime.datetime.now()
         expected_time += datetime.timedelta(seconds=expected_diff)
         assert incremented_time == expected_time
+
+
+def test_as_arg():
+    @freeze_time("2012-01-14", as_arg=True)
+    def as_arg(frozen, arg):
+        assert frozen.time_to_freeze == datetime.datetime(2012, 1, 14, 0, 0)
+        assert arg == 1
+    as_arg(1)
+
+
+def test_as_kwarg():
+    @freeze_time("2012-01-14", as_kwarg="frozen")
+    def as_arg(frozen=None, *, kwarg):
+        assert frozen.time_to_freeze == datetime.datetime(2012, 1, 14, 0, 0)
+        assert kwarg == 1
+
+    as_arg(kwarg=1)
+

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -1,7 +1,9 @@
 import datetime
 import fractions
 import pytest
+import typing
 from freezegun import freeze_time
+from freezegun.api import StepTickTimeFactory, TickingDateTimeFactory, FrozenDateTimeFactory
 from dateutil.relativedelta import relativedelta
 from datetime import timedelta, tzinfo
 from tests import utils
@@ -141,19 +143,24 @@ def test_auto_and_manual_tick(
         assert incremented_time == expected_time
 
 
-def test_as_arg():
+def test_as_arg()->None:
     @freeze_time("2012-01-14", as_arg=True)
-    def as_arg(frozen, arg):
+    def as_arg(frozen: typing.Optional[TickingDateTimeFactory]=None,
+               arg: typing.Optional[int]=None
+    ) -> None :
+        assert frozen
         assert frozen.time_to_freeze == datetime.datetime(2012, 1, 14, 0, 0)
         assert arg == 1
-    as_arg(1)
+
+    as_arg(arg=1)
 
 
-def test_as_kwarg():
+def test_as_kwarg()->None:
     @freeze_time("2012-01-14", as_kwarg="frozen")
-    def as_arg(frozen=None, *, kwarg):
+    def as_arg(arg: int, frozen: typing.Optional[TickingDateTimeFactory]=None) -> None:
+        assert frozen
         assert frozen.time_to_freeze == datetime.datetime(2012, 1, 14, 0, 0)
-        assert kwarg == 1
+        assert arg == 1
 
-    as_arg(kwarg=1)
+    as_arg(arg=1)
 


### PR DESCRIPTION
Since 1.5.4, @freeze_time("2012-01-14", as_arg=True) is not working.

```
❯ python
Python 3.13.1 (main, Feb  5 2025, 16:35:55) [GCC 13.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import freezegun
>>> freezegun.__version__
'1.5.5'
>>> @freezegun.freeze_time("2012-01-14", as_arg=True)
... def test(frozen_time):
...     pass
...
>>> test()
Traceback (most recent call last):
  File "<python-input-3>", line 1, in <module>
    test()
    ~~~~^^
  File "/home/ishimoto/src/freezegun.orig/freezegun/api.py", line 951, in wrapper
    return self._call_with_time_factory(time_factory, func=func, args=args, kwargs=kwargs)
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ishimoto/src/freezegun.orig/freezegun/api.py", line 934, in _call_with_time_factory
    result = func(*args, **kwargs)
TypeError: test() missing 1 required positional argument: 'frozen_time'
```