### PR TITLE
Fix datetime.datetime.now() different behavior with and without freeze_time usage

### DIFF
--- a/freezegun/api.py
+++ b/freezegun/api.py
@@ -401,7 +401,7 @@ class FakeDatetime(real_datetime, FakeDate, metaclass=FakeDatetimeMeta):
     def now(cls, tz: Optional[datetime.tzinfo] = None) -> "FakeDatetime":
         now = cls._time_to_freeze() or real_datetime.now()
         if tz:
-            result = tz.fromutc(now.replace(tzinfo=tz)) + cls._tz_offset()
+            result = now.replace(tzinfo=tz) + cls._tz_offset()
         else:
             result = now + cls._tz_offset()
         return datetime_to_fakedatetime(result)

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -64,14 +64,14 @@ class GMT5(tzinfo):
 @freeze_time("2012-01-14 2:00:00")
 def test_datetime_timezone_real() -> None:
     now = datetime.datetime.now(tz=GMT5())
-    assert now == datetime.datetime(2012, 1, 14, 7, tzinfo=GMT5())
+    assert now == datetime.datetime(2012, 1, 14, 2, tzinfo=GMT5())
     assert now.utcoffset() == timedelta(0, 60 * 60 * 5)
 
 
 @freeze_time("2012-01-14 2:00:00", tz_offset=-4)
 def test_datetime_timezone_real_with_offset() -> None:
     now = datetime.datetime.now(tz=GMT5())
-    assert now == datetime.datetime(2012, 1, 14, 3, tzinfo=GMT5())
+    assert now == datetime.datetime(2012, 1, 13, 22, tzinfo=GMT5())
     assert now.utcoffset() == timedelta(0, 60 * 60 * 5)
 
 


### PR DESCRIPTION
I realized that when using freeze_time with a given tz, the behavior differs from the standard datetime library.

Steps to reproduce:

```python
import datetime
from zoneinfo import ZoneInfo
from freezegun.api import freeze_time

def compare_datetime_now():
    now = datetime.datetime.now()
    now_with_tz = datetime.datetime.now(tz=ZoneInfo("Europe/Paris"))
    print(now)
    print(now_with_tz)
    return now.hour == now_with_tz.hour

with freeze_time("2022-11-8 06:10:00"):
    print(compare_datetime_now())

print(compare_datetime_now())
```

Here is a quick fix. 
I don't know if it has other impacts but all tests are OK (I only had to modify 2 of them)

Regards.