### PR TITLE
Set uuid._last_timestamp_v7=None to reset uiud7() when enter/exit context

### DIFF
--- a/freezegun/api.py
+++ b/freezegun/api.py
@@ -772,6 +772,7 @@ class _freeze_time:
             setattr(uuid, uuid_generate_time_attr, None)
         uuid._UuidCreate = None  # type: ignore[attr-defined]
         uuid._last_timestamp = None  # type: ignore[attr-defined]
+        uuid._last_timestamp_v7 = None  # type: ignore[attr-defined]
 
         copyreg.dispatch_table[real_datetime] = pickle_fake_datetime
         copyreg.dispatch_table[real_date] = pickle_fake_date
@@ -912,6 +913,7 @@ class _freeze_time:
                 setattr(uuid, uuid_generate_time_attr, real_uuid_generate_time)
             uuid._UuidCreate = real_uuid_create  # type: ignore[attr-defined]
             uuid._last_timestamp = None  # type: ignore[attr-defined]
+            uuid._last_timestamp_v7 = None  # type: ignore[attr-defined]
 
     def decorate_coroutine(self, coroutine: "Callable[P, Awaitable[T]]") -> "Callable[P, Awaitable[T]]":
         return wrap_coroutine(self, coroutine)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ pytest
 pytest-cov
 coveralls
 python-dateutil >= 2.7
-maya; python_version < '3.12'
+maya; python_version < '3.15'

--- a/tests/test_uuid.py
+++ b/tests/test_uuid.py
@@ -1,7 +1,8 @@
 import datetime
 import uuid
 from typing import Any
-
+import pytest
+import sys
 from freezegun import freeze_time
 
 
@@ -13,6 +14,19 @@ def time_from_uuid(value: Any) -> datetime.datetime:
     assert uvalue.version == 1
     return (datetime.datetime(1582, 10, 15) +
             datetime.timedelta(microseconds=uvalue.time // 10))
+
+def time_from_uuid7(value: Any) -> datetime.datetime:
+    """
+    Converts an UUID(7) to it's datetime value
+    """
+    uvalue = value if isinstance(value, uuid.UUID) else uuid.UUID(value)
+    assert uvalue.version == 7
+    # UUID as 128-bit integer
+    uuid_int = uvalue.int
+    
+    # Extract the first 48 bits (timestamp in ms)
+    timestamp_ms = uuid_int >> 80
+    return datetime.datetime.fromtimestamp(timestamp_ms / 1000)
 
 
 def test_uuid1_future() -> None:
@@ -43,7 +57,10 @@ def test_uuid1_past() -> None:
     with freeze_time(future_target):
         assert time_from_uuid(uuid.uuid1()) == future_target
 
-
+@pytest.mark.skipif(
+    sys.version_info < (3, 14),
+    reason="Only valid on Python 3.14+",
+)
 def test_uuid7_future() -> None:
     """
     Test that we can go back in time after setting a future date.
@@ -52,11 +69,11 @@ def test_uuid7_future() -> None:
     """
     future_target = datetime.datetime(2056, 2, 6, 14, 3, 21)
     with freeze_time(future_target):
-        assert time_from_uuid(uuid.uuid7()) == future_target
+        assert time_from_uuid7(uuid.uuid7()) == future_target
 
     past_target = datetime.datetime(1978, 7, 6, 23, 6, 31)
     with freeze_time(past_target):
-        assert time_from_uuid(uuid.uuid7()) == past_target
+        assert time_from_uuid7(uuid.uuid7()) == past_target
 
 
 def test_uuid7_past() -> None:
@@ -66,9 +83,9 @@ def test_uuid7_past() -> None:
     """
     past_target = datetime.datetime(1978, 7, 6, 23, 6, 31)
     with freeze_time(past_target):
-        assert time_from_uuid(uuid.uuid1()) == past_target
+        assert time_from_uuid7(uuid.uuid7()) == past_target
 
     future_target = datetime.datetime(2056, 2, 6, 14, 3, 21)
     with freeze_time(future_target):
-        assert time_from_uuid(uuid.uuid1()) == future_target
+        assert time_from_uuid7(uuid.uuid7()) == future_target
 

--- a/tests/test_uuid.py
+++ b/tests/test_uuid.py
@@ -75,7 +75,10 @@ def test_uuid7_future() -> None:
     with freeze_time(past_target):
         assert time_from_uuid7(uuid.uuid7()) == past_target
 
-
+@pytest.mark.skipif(
+    sys.version_info < (3, 14),
+    reason="Only valid on Python 3.14+",
+)
 def test_uuid7_past() -> None:
     """
     Test that we can go forward in time after setting some time in the past.

--- a/tests/test_uuid.py
+++ b/tests/test_uuid.py
@@ -42,3 +42,33 @@ def test_uuid1_past() -> None:
     future_target = datetime.datetime(2056, 2, 6, 14, 3, 21)
     with freeze_time(future_target):
         assert time_from_uuid(uuid.uuid1()) == future_target
+
+
+def test_uuid7_future() -> None:
+    """
+    Test that we can go back in time after setting a future date.
+    Normally UUID7 would disallow this, since it keeps track of
+    the _last_timestamp_v7, but we override that now.
+    """
+    future_target = datetime.datetime(2056, 2, 6, 14, 3, 21)
+    with freeze_time(future_target):
+        assert time_from_uuid(uuid.uuid7()) == future_target
+
+    past_target = datetime.datetime(1978, 7, 6, 23, 6, 31)
+    with freeze_time(past_target):
+        assert time_from_uuid(uuid.uuid7()) == past_target
+
+
+def test_uuid7_past() -> None:
+    """
+    Test that we can go forward in time after setting some time in the past.
+    This is simply the opposite of test_uuid7_future()
+    """
+    past_target = datetime.datetime(1978, 7, 6, 23, 6, 31)
+    with freeze_time(past_target):
+        assert time_from_uuid(uuid.uuid1()) == past_target
+
+    future_target = datetime.datetime(2056, 2, 6, 14, 3, 21)
+    with freeze_time(future_target):
+        assert time_from_uuid(uuid.uuid1()) == future_target
+

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py37, py38, py39, py310, py311, py312, pypy3, mypy
+envlist = py37, py38, py39, py310, py311, py312, py313, py314, pypy3, mypy
 
 [testenv]
 commands = pytest --cov {posargs}


### PR DESCRIPTION
While `freezegun` does not officially support python 3.14 (at least in tests), it works almost perfectly, (except for `UUID7`). 

I've added `py314` into `tox` and change the requirements for Maya. This ended up making the PR too broad for my liking. 

If eventually freezegun updates to support 3.14, please consider this change. 