### PR TITLE
fix: keep freeze_time across Process on Python 3.14

### DIFF
--- a/freezegun/api.py
+++ b/freezegun/api.py
@@ -579,6 +579,34 @@ class StepTickTimeFactory:
         self.tick(delta=delta)
 
 
+def _prefer_fork_start_method() -> bool:
+    """Set the ``fork`` start method while frozen, unless one was already chosen.
+
+    Python 3.14 switched the default Linux start method to ``forkserver``,
+    which starts a fresh interpreter and loses freezegun patches (#593).
+    ``fork`` children inherit the patched modules, restoring 3.13 behavior.
+
+    An explicitly configured start method is always respected.  Returns True
+    only when this call set the method itself, so stop() can restore the
+    previous unset state.
+    """
+    if sys.platform == "win32":
+        return False
+    try:
+        import multiprocessing as mp
+    except Exception:
+        return False
+    try:
+        if "fork" not in mp.get_all_start_methods():
+            return False
+        if mp.get_start_method(allow_none=True) is not None:
+            return False  # explicit user/framework choice: do not override
+        mp.set_start_method("fork")
+        return True
+    except Exception:
+        return False
+
+
 class _freeze_time:
     """
     A class to freeze time for testing purposes.
@@ -631,6 +659,7 @@ class _freeze_time:
         self.as_arg = as_arg
         self.as_kwarg = as_kwarg
         self.real_asyncio = real_asyncio
+        self._mp_fork_set_by_us: bool = False
 
     # mypy objects to this because Type is Callable, but Pytype needs it because
     # (unlike mypy's) its inference does not assume class decorators always leave
@@ -755,6 +784,11 @@ class _freeze_time:
         ignore_lists.append(self.ignore)
         tick_flags.append(self.tick)
 
+        if not is_already_started:
+            # Let Process children inherit frozen time on Unix (#593); a
+            # start method explicitly chosen by the caller stays untouched.
+            self._mp_fork_set_by_us = _prefer_fork_start_method()
+
         if is_already_started:
             return freeze_factory
 
@@ -856,6 +890,17 @@ class _freeze_time:
         tz_offsets.pop()
 
         if not freeze_factories:
+            if self._mp_fork_set_by_us:
+                try:
+                    import multiprocessing as mp
+
+                    # Restore the unset state we found, unless the caller
+                    # changed the start method while time was frozen.
+                    if mp.get_start_method(allow_none=True) == "fork":
+                        mp.set_start_method(None, force=True)
+                except Exception:
+                    pass
+                self._mp_fork_set_by_us = False
             datetime.datetime = real_datetime  # type: ignore[misc]
             datetime.date = real_date  # type: ignore[misc]
             copyreg.dispatch_table.pop(real_datetime)

--- a/tests/test_multiprocess_freeze.py
+++ b/tests/test_multiprocess_freeze.py
@@ -1,0 +1,67 @@
+import datetime
+import multiprocessing as mp
+import sys
+from multiprocessing.queues import Queue as MpQueue
+
+import pytest
+
+from freezegun import freeze_time
+
+
+class _QueueProcess(mp.Process):
+    def __init__(self, data_queue: "MpQueue[datetime.datetime]") -> None:
+        self._data_queue = data_queue
+        mp.Process.__init__(self)
+
+    def run(self) -> None:
+        self._data_queue.put(datetime.datetime.now())
+
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32", reason="fork start method is unavailable on Windows"
+)
+
+
+def _reset_start_method() -> None:
+    # Test hygiene: restore the unset state (public reset API).
+    mp.set_start_method(None, force=True)
+
+
+def teardown_module() -> None:
+    _reset_start_method()
+
+
+@freeze_time("2012-01-14")
+def test_freeze_time_propagates_to_process_child() -> None:
+    """Regression #593: Py3.14 default start method broke child freeze inheritance."""
+    queue: "MpQueue[datetime.datetime]" = mp.Queue()
+    process = _QueueProcess(queue)
+    process.start()
+    result = queue.get(timeout=10)
+    process.join(timeout=10)
+    assert result == datetime.datetime(2012, 1, 14)
+
+
+def test_unset_start_method_restored_after_freeze() -> None:
+    # The unset state must survive a freeze/unfreeze cycle untouched.
+    assert mp.get_start_method(allow_none=True) is None
+    with freeze_time("2012-01-14"):
+        assert mp.get_start_method() == "fork"
+    assert mp.get_start_method(allow_none=True) is None
+
+
+def test_explicit_start_method_choice_is_respected() -> None:
+    mp.set_start_method("forkserver")
+    try:
+        with freeze_time("2012-01-14"):
+            assert mp.get_start_method() == "forkserver"
+        assert mp.get_start_method() == "forkserver"
+    finally:
+        _reset_start_method()
+
+
+def test_repeated_freeze_cycles_do_not_leak_state() -> None:
+    for _ in range(3):
+        with freeze_time("2012-01-14"):
+            assert datetime.datetime.now() == datetime.datetime(2012, 1, 14)
+    assert mp.get_start_method(allow_none=True) is None


### PR DESCRIPTION
## Summary
Python 3.14 made forkserver the default start method on Linux, so multiprocessing.Process children no longer inherit frozen time (#593).

While frozen and no start method was explicitly chosen, freezegun now sets fork (restoring pre-3.14 behavior) and restores the previous unset state on stop() via the public set_start_method(None, force=True) reset. An explicitly configured start method is never overridden. Windows and platforms without fork are untouched.

## Test plan
- [x] Reproduced on Python 3.14.7 (child saw wall clock) before the fix
- [x] Full suite on Python 3.14.7: 147 passed, 6 skipped
- [x] Full suite on Python 3.13.15: 147 passed, 6 skipped
- [x] mypy --strict: no new findings vs master
- [x] New tests cover: issue repro, unset-state restore after unfreeze, explicit start-method choice respect, repeated freeze cycles without state leaks

Fixes #593