### PR TITLE
fix: preserve datetime fold in FakeDatetime conversions

### DIFF
--- a/freezegun/api.py
+++ b/freezegun/api.py
@@ -303,14 +303,17 @@ class FakeDateMeta(type):
 
 
 def datetime_to_fakedatetime(datetime: datetime.datetime) -> "FakeDatetime":
-    return FakeDatetime(datetime.year,
-                        datetime.month,
-                        datetime.day,
-                        datetime.hour,
-                        datetime.minute,
-                        datetime.second,
-                        datetime.microsecond,
-                        datetime.tzinfo)
+    return FakeDatetime(
+        datetime.year,
+        datetime.month,
+        datetime.day,
+        datetime.hour,
+        datetime.minute,
+        datetime.second,
+        datetime.microsecond,
+        datetime.tzinfo,
+        fold=getattr(datetime, "fold", 0),
+    )
 
 
 def date_to_fakedate(date: datetime.date) -> "FakeDate":

--- a/tests/test_dst_fold_astimezone.py
+++ b/tests/test_dst_fold_astimezone.py
@@ -1,0 +1,31 @@
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+from freezegun import freeze_time
+from freezegun.api import datetime_to_fakedatetime, real_datetime
+
+
+def test_datetime_to_fakedatetime_preserves_fold():
+    tz = ZoneInfo("US/Eastern")
+    # Second 01:00 on fall-back day (fold=1) via real conversion
+    real = real_datetime.fromisoformat("2025-11-02T06:00:00+00:00").astimezone(tz)
+    assert real.fold == 1
+    fake = datetime_to_fakedatetime(real)
+    assert fake.fold == real.fold
+    assert fake.strftime("%H:%M %Z") == real.strftime("%H:%M %Z")
+
+
+def test_astimezone_dst_fold_matches_stdlib_under_freeze():
+    """Regression #596: freezegun must not collapse EST fold hour to EDT."""
+    tz = ZoneInfo("US/Eastern")
+    utc_keys = [f"2025-11-02T{h:02d}:00:00+00:00" for h in range(4, 9)]
+    expected = [
+        datetime.fromisoformat(k).astimezone(tz).strftime("%H:%M %Z") for k in utc_keys
+    ]
+    with freeze_time("2025-11-01 11:30:00Z"):
+        got = [
+            datetime.fromisoformat(k).astimezone(tz).strftime("%H:%M %Z") for k in utc_keys
+        ]
+    assert got == expected
+    # specifically the fold hour must be EST not EDT
+    assert got[2].endswith("EST")


### PR DESCRIPTION
## Summary
`datetime_to_fakedatetime` dropped the `fold` flag, so DST fall-back conversions through `FakeDatetime.astimezone` collapsed the second 01:00 (EST) into EDT under `freeze_time` (issue #596).

Pass `fold` through when constructing `FakeDatetime`.

## Test plan
- [x] Reproduced issue script on Python 3.14.4 Daytona sandbox
- [x] `pytest tests/test_dst_fold_astimezone.py` PASS on 3.14.4 after patch

Fixes #596
